### PR TITLE
Fix links to topics with targets

### DIFF
--- a/basic_config/basic_config_book.ditamap
+++ b/basic_config/basic_config_book.ditamap
@@ -35,7 +35,7 @@
 		<topicref format="dita" href="data_entries_custom_classes/chapter_overview.xml">
 			<topicref href="data_entries_custom_classes/managing_data_entries.xml"/>
 			<topicref
-				href="data_entries_custom_classes/using_custom_classes.xml#using_custom_classes"/>
+				href="data_entries_custom_classes/using_custom_classes.xml"/>
 		</topicref>
 	</part>
 </bookmap>

--- a/basic_config/data_entries_custom_classes/managing_data_entries.xml
+++ b/basic_config/data_entries_custom_classes/managing_data_entries.xml
@@ -22,9 +22,9 @@ this.currRegion.put(name,value); </codeblock><note>You
 					can also use the <codeph>gfsh <cmdname>put</cmdname></codeph> command to add
 					entries to a region, and the <cmdname>get</cmdname> command to retrieve entries
 					from a region. See <xref
-						href="../../tools_modules/gfsh/command-pages/get.xml#concept_837F6196CE334C8CA2CAFD34AB6EF869"
+						href="../../tools_modules/gfsh/command-pages/get.xml"
 					/> and <xref format="dita"
-						href="../../tools_modules/gfsh/command-pages/put.xml#concept_2ECE1BB23A814A13924C93422E7EBC5E"
+						href="../../tools_modules/gfsh/command-pages/put.xml"
 						scope="local" type="concept"/> for more information. </note></p>
 			<p>If you want only to create the entry (with a null value and with method failure if
 				the entry already exists), use <codeph>Region.create</codeph> instead. </p>
@@ -165,9 +165,9 @@ region.put("stringBuf", s);</codeblock>
 			<title>Using gfsh to get and put </title>
 			<p>You can use the gfsh <cmdname>get</cmdname> and <cmdname>put</cmdname> commands to
 				manage data. See <xref
-					href="../../tools_modules/gfsh/command-pages/get.xml#concept_837F6196CE334C8CA2CAFD34AB6EF869"
+					href="../../tools_modules/gfsh/command-pages/get.xml"
 				/> and <xref
-					href="../../tools_modules/gfsh/command-pages/put.xml#concept_2ECE1BB23A814A13924C93422E7EBC5E"
+					href="../../tools_modules/gfsh/command-pages/put.xml"
 				/>.</p>
 			<p>For example:<codeblock outputclass="language-java">
 get --key=('id':'133abg124') --region=region1

--- a/basic_config/data_entries_custom_classes/using_custom_classes.xml
+++ b/basic_config/data_entries_custom_classes/using_custom_classes.xml
@@ -15,7 +15,7 @@
 						the <codeph>CLASSPATH</codeph> environment variable or the <codeph>gfsh
 							start server</codeph>'s <codeph>--classpath</codeph> parameter. See
 							<xref
-							href="../../configuring/running/running_the_cacheserver.xml#running_the_cacheserver"
+							href="../../configuring/running/running_the_cacheserver.xml"
 							type="concept" format="dita" scope="local"/>. </li>
 				</ul>
 			</p>

--- a/basic_config/data_regions/create_a_region_with_gfsh.xml
+++ b/basic_config/data_regions/create_a_region_with_gfsh.xml
@@ -36,7 +36,7 @@
 				<cmd>Add data into the region by using the <xref
 						href="../../tools_modules/gfsh/command-pages/import.xml#topic_jw2_2ld_2l"
 					/>command or <xref format="dita"
-						href="../../tools_modules/gfsh/command-pages/put.xml#concept_2ECE1BB23A814A13924C93422E7EBC5E"
+						href="../../tools_modules/gfsh/command-pages/put.xml"
 						scope="local" type="concept">put</xref> gfsh command. </cmd>
 			</step>
 			<step id="step_FB018B9592F542AA9A12B802D2458C8F">
@@ -58,7 +58,7 @@
 						you start that attach to the same locator receive the same configuration.
 						You can also create alternate configurations within a distributed system by
 						specifying a group when creating the region and starting servers. See <xref
-							href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+							href="../../configuring/cluster_config/gfsh_persist.xml"
 						/>.</note>
 				</info>
 			</step>

--- a/basic_config/data_regions/managing_data_regions.xml
+++ b/basic_config/data_regions/managing_data_regions.xml
@@ -111,7 +111,7 @@
 				<ol id="ol_1BF5C8C9F4C9460AB6FB6030451CEBF6">
 					<li id="li_FD265BA2AE244AC581C235029F38E46E">Determine the region attributes
 						requirements and identify the region shortcut setting that most closely
-						matches your needs. See <xref href="region_shortcuts.xml#region_shortcuts"/>
+						matches your needs. See <xref href="region_shortcuts.xml"/>
 						and <xref href="../../reference/topics/chapter_overview_regionshortcuts.xml"
 						/> for more information.</li>
 					<li id="li_ABE1A5B1612844BE80F2953253FB5B17">Define any region attributes that
@@ -344,7 +344,7 @@ Region.InvalidateRegion(); </codeblock>
 				configuration and create the specified regions. You can also define <i>groups</i>
 				that apply only to some of the servers in the cluster. Servers you start that
 				specify a group also receive the group configuration from the cluster configuration
-				service. See <xref href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+				service. See <xref href="../../configuring/cluster_config/gfsh_persist.xml"
 				/>.</p>See<xref
 				href="create_a_region_with_gfsh.xml#task_75639BFA7847461D9E006E91B728BB44"/> and
 				<xref

--- a/basic_config/gemfire_properties/setting_distributed_properties.xml
+++ b/basic_config/gemfire_properties/setting_distributed_properties.xml
@@ -72,7 +72,7 @@ ClientCache userCache =
 									line as command-line options. Example:
 									<codeblock>gfsh&gt;start server --name=<varname>server_name</varname> --mcast-port=10338 --properties-file=serverConfig/gemfire.properties --security-properties-file=gfsecurity.properties</codeblock>
 									See <xref
-										href="../../configuring/running/running_the_cacheserver.xml#running_the_cacheserver"
+										href="../../configuring/running/running_the_cacheserver.xml"
 										type="concept" format="dita" scope="local"/> for more
 									information on running cache servers. </li>
 							</ul>
@@ -80,7 +80,7 @@ ClientCache userCache =
 					</li>
 					<li id="li_862F33E7428E46F4B2AEC8E08E6DFC5F">Entry in a
 							<codeph>gemfire.properties</codeph> file. See <xref
-							href="../../configuring/running/deploying_config_files.xml#deploying_config_files"
+							href="../../configuring/running/deploying_config_files.xml"
 							format="dita"/>. Example:
 						<codeblock>cache-xml-file=cache.xml
 conserve-sockets=true

--- a/basic_config/the_cache/intro_cache_management.xml
+++ b/basic_config/the_cache/intro_cache_management.xml
@@ -102,7 +102,7 @@
 				member processes and create each member’s <keyword keyref="product_name"/> cache. If
 				you are using the cluster configuration service, member processes can pick up its
 				cache configuration from the cluster or group's current configuration. See <xref
-					href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+					href="../../configuring/cluster_config/gfsh_persist.xml"
 				/>.</p>
 			<p>The steps in this section use <codeph>gemfire.properties</codeph> and
 					<codeph>cache.xml</codeph> file examples, except where API is required. You can
@@ -150,7 +150,7 @@
 				commands, the Cluster Configuration Service saves cache.xml and gemfire.properties
 				files on the locators and distributes those configurations to any new members that
 				join the cluster. See <xref
-					href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+					href="../../configuring/cluster_config/gfsh_persist.xml"
 				/>.</p>
 		</section>
 	</conbody>

--- a/basic_config/the_cache/setting_cache_properties.xml
+++ b/basic_config/the_cache/setting_cache_properties.xml
@@ -26,7 +26,7 @@
 							that apply to the entire cluster and also saves configurations that only
 							apply to defined groups of members within the cluster. You can re-use
 							these configurations to create a distributed system. See <xref
-								href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+								href="../../configuring/cluster_config/gfsh_persist.xml"
 							/>.</p></li>
 					<li id="li_F0B7F989BA9247EB997AC0A78D3650B1">Through declarations in the XML
 						file named in the <codeph>cache-xml-file</codeph>

--- a/configuring/cluster_config/create_persistent_config.xml
+++ b/configuring/cluster_config/create_persistent_config.xml
@@ -80,7 +80,7 @@ Member  | Deployed JAR | Deployed JAR Location
 server1 | myApp.jar    | /home/erawlings/gf80/jul9/startup2/server1/vf.gf#myApp.jar#1
 </codeblock>
                     <p>See <xref
-                            href="../../tools_modules/gfsh/command-pages/deploy.xml#concept_6B38CB283BC048778A8E3908C1BDF221"/></p>
+                            href="../../tools_modules/gfsh/command-pages/deploy.xml"/></p>
                 </info>
             </step>
             <step>

--- a/configuring/cluster_config/deploying_application_jars.xml
+++ b/configuring/cluster_config/deploying_application_jars.xml
@@ -21,7 +21,7 @@
 			<codeblock>gfsh&gt; deploy --jar=group1_functions.jar --group=MemberGroup1</codeblock>In
 			the example it is assumed that you have already defined the member group that you want
 			to use when starting up your members. See <xref format="dita"
-				href="using_member_groups.xml#concept_5B60087DA11644C49250064BAB8AFFA6"
+				href="using_member_groups.xml"
 				scope="local" type="concept"/> for more information on how to define member groups
 			and add a member to a group. </p>
 		<p>To deploy all the JAR files that are located in a specific directory to all members:
@@ -47,8 +47,7 @@ datanode1 | group1_functions.jar | /usr/local/gemfire/deploy/vf.gf#group1_functi
 datanode2 | group1_functions.jar | /usr/local/gemfire/deploy/vf.gf#group1_functions.jar#1</codeblock>
 		</p>
 		<p>For more information on <codeph>gfsh</codeph> usage, see <xref format="dita"
-				href="../../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
-				scope="local" type="concept"/>. </p>
+				href="../../tools_modules/gfsh/chapter_overview.xml" scope="local" type="concept"/>. </p>
 		<section id="section_D36E345C6E254D27B0F4B0C8711F5E6A">
 			<title>Deployment Location for JAR Files</title>
 			<p>The system location where JAR files are written on each member is determined by the
@@ -70,7 +69,7 @@ deploy-working-dir=/usr/local/gemfire/deploy</codeblock>
 				locators in the distributed system. When you start a new server using gfsh, the
 				locator supplies configuration files and deployed jar files to the member and writes
 				them to the server's directory. </p>
-			<p>See <xref href="gfsh_persist.xml#concept_r22_hyw_bl"/>. </p>
+			<p>See <xref href="gfsh_persist.xml"/>. </p>
 		</section>
 		<section id="section_D9219C5EEED64672930200677C2118C9">
 			<title>Versioning of JAR Files</title>

--- a/configuring/cluster_config/gfsh_example.xml
+++ b/configuring/cluster_config/gfsh_example.xml
@@ -164,7 +164,7 @@
 	 </table> 
 	 <p> For details about index, see 
 		<xref
-		 href="../../developing/querying_basics/chapter_overview.xml#querying_with_oql"
+		 href="../../developing/querying_basics/chapter_overview.xml"
 		 type="concept" format="dita" scope="local"><?xm-replace_text Querying?></xref>.
 		
 	 </p> 

--- a/configuring/cluster_config/gfsh_persist.xml
+++ b/configuring/cluster_config/gfsh_persist.xml
@@ -48,7 +48,7 @@
       <p>You can also load existing configuration files into the cluster configuration service by
         starting up a standalone locator with the parameter
           <codeph>--load-cluster-configuration-from-dir</codeph> set to true. See <xref
-          href="gfsh_load_from_shared_dir.xml#concept_hbk_sgb_y4"/>.</p>
+          href="gfsh_load_from_shared_dir.xml"/>.</p>
     </section>
     <section>
       <title>How the Cluster Configuration Service Works</title>

--- a/configuring/cluster_config/gfsh_remote.xml
+++ b/configuring/cluster_config/gfsh_remote.xml
@@ -40,7 +40,7 @@
 
 Successfully connected to: GemFire Manager's HTTP service @ http://my.remote.cluster:8080/gemfire/v1</codeblock>
                     <p>See <xref
-                            href="../../tools_modules/gfsh/command-pages/connect.xml#concept_C2DCEE6743304549825C9B62E66DBADF"/>.</p>
+                            href="../../tools_modules/gfsh/command-pages/connect.xml"/>.</p>
                     <p>gfsh is now connected to the remote system. Most gfsh commands will now
                         execute on the remote system; however, there are exceptions. The following
                         commands are executed on the local cluster :</p>
@@ -107,7 +107,7 @@ Successfully connected to: GemFire Manager's HTTP service @ http://my.remote.clu
             </ul>
             <p
                 dir="ltr">See <xref
-                    href="../../managing/security/ssl_overview.xml#ssl"/> for details on configuring
+                    href="../../managing/security/ssl_overview.xml"/> for details on configuring
                 these parameters.</p>
             <p
                 dir="ltr">The above parameters also apply to all HTTP services hosted on the

--- a/configuring/cluster_config/using_member_groups.xml
+++ b/configuring/cluster_config/using_member_groups.xml
@@ -43,10 +43,10 @@
 		<p>A single member can belong to more than one group. </p>
 		<p>Member groups can also be used to organize members from either a client's perspective or
 			from a peer member's perspective. See <xref
-				href="../../topologies_and_comm/p2p_configuration/configuring_peer_member_groups.xml#concept_032521546EF34FABB40EB2C18080ED35"
+				href="../../topologies_and_comm/p2p_configuration/configuring_peer_member_groups.xml"
 				type="concept" format="dita" scope="local"
 				><?xm-replace_text Organizing Peers into Logical Member Groups?></xref> and <xref
-				href="../../topologies_and_comm/cs_configuration/configure_servers_into_logical_groups.xml#configure_servers_into_logical_groups"
+				href="../../topologies_and_comm/cs_configuration/configure_servers_into_logical_groups.xml"
 				type="concept" format="dita" scope="local"
 				><?xm-replace_text Organizing Servers Into Logical Member Groups?></xref> for more
 			information. On the client side, you can supply the member group name when configuring a

--- a/configuring/running/deploying_config_files.xml
+++ b/configuring/running/deploying_config_files.xml
@@ -11,7 +11,7 @@
 				keyref="product_name_long"/> cluster configuration, the procedures described in this
 			section are not needed because <keyword keyref="product_name"/> automatically manages
 			the distribution of the configuration files and jar files to members of the cluster. See
-				<xref href="../cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"/>.<p>You can use
+				<xref href="../cluster_config/gfsh_persist.xml"/>.<p>You can use
 				the procedures described in this section to distribute configurations that are
 				member-specific, or for situations where you do not want to use the cluster
 				configuration service. </p></note>

--- a/configuring/running/firewalls_connections.xml
+++ b/configuring/running/firewalls_connections.xml
@@ -23,7 +23,7 @@
 					><?xm-replace_text How Client/Server Connections Work?></xref>
 			</li>
 			<li id="li_64A2D984FD664036826FEFFD4D77A46F"><xref
-					href="../../managing/monitor_tune/socket_communication.xml#socket_comm"
+					href="../../managing/monitor_tune/socket_communication.xml"
 					type="concept" format="dita" scope="local"
 					><?xm-replace_text Socket Communication?></xref>
 			</li>
@@ -33,7 +33,7 @@
 					><?xm-replace_text Controlling Socket Use?></xref>
 			</li>
 			<li id="li_31BBF9CD4BA0468F96C26C2027A3C150"><xref
-					href="../../managing/monitor_tune/socket_communication_setting_socket_buffer_sizes.xml#socket_comm"
+					href="../../managing/monitor_tune/socket_communication_setting_socket_buffer_sizes.xml"
 					type="concept" format="dita" scope="local"
 					><?xm-replace_text Setting Socket Buffer Sizes?></xref>
 			</li>

--- a/configuring/running/gemfire_command_line_utility.xml
+++ b/configuring/running/gemfire_command_line_utility.xml
@@ -457,7 +457,7 @@ shut-down-all</codeblock>
 						</li> 
 					 </ul>See 
 					 <xref
-					 href="../../managing/statistics/chapter_overview.xml#statistics" type="concept"
+					 href="../../managing/statistics/chapter_overview.xml" type="concept"
 					 format="dita" scope="local"><?xm-replace_text Statistics?></xref> for more
 					 information. 
 				  </entry> 

--- a/configuring/running/locators_gateways.xml
+++ b/configuring/running/locators_gateways.xml
@@ -24,7 +24,7 @@
 		<p>Clients need only be able to connect to the locator's locator port. They don't interact
 			with the locator's distributed system; clients get server names and ports from the
 			locator and use these to connect to the servers. For more information, see <xref
-				href="running_the_locator.xml#running_the_locator" type="concept" format="dita"
+				href="running_the_locator.xml" type="concept" format="dita"
 				scope="local"><?xm-replace_text vFabric GemFire Locator Process?></xref>. </p>
 	</conbody>
 </concept>

--- a/configuring/running/managing_output_files.xml
+++ b/configuring/running/managing_output_files.xml
@@ -33,7 +33,7 @@
 						clients can be overflowed to disk. Gateway sender queues overflow to disk
 						automatically and can be persisted for high availability. Configure these
 						through the <codeph>cache.xml</codeph>. See <xref
-							href="../../managing/disk_storage/chapter_overview.xml#disk_storage"
+							href="../../managing/disk_storage/chapter_overview.xml"
 							type="concept" format="dita" scope="local"/>. <p/>
 					</li>
 				</ul>

--- a/configuring/running/running_the_locator.xml
+++ b/configuring/running/running_the_locator.xml
@@ -34,7 +34,7 @@
 						<codeph>$GEMFIRE/lib/locator-dependencies.jar</codeph> inside the command
 					used to launch the locator process. For more information on CLASSPATH settings
 					in <keyword keyref="product_name"/>, see <xref
-						href="../../getting_started/setup_gemfire_classpath.xml#concept_ivh_glr_l4"
+						href="../../getting_started/setup_gemfire_classpath.xml"
 					/>. You can modify the CLASSPATH by specifying the --classpath or parameter</li>
 				<li id="li_2BB86FA6977646CF923BCB5B878ECD57">Locators are members of the distributed
 					system just like any other member. In terms of <codeph>mcast-port</codeph> and
@@ -77,7 +77,7 @@ mcast-port=0</codeblock>
 					try to reconnect to the existing distributed system. When a locator is in the
 					reconnecting state, it provides no discovery services for the distributed
 					system. See <xref
-						href="../../managing/autoreconnect/member-reconnect.xml#concept_22EE6DDE677F4E8CAF5786E17B4183A9"
+						href="../../managing/autoreconnect/member-reconnect.xml"
 					/> for more details.</li>
 			</ul>
 		</section>
@@ -88,7 +88,7 @@ mcast-port=0</codeblock>
 				saved in the Locator's directory and are propagated to all locators in a distributed
 				system. When you start servers using gfsh, the servers receive the group-level and
 				cluster-level configurations from the locators. </p>
-			<p>See<xref href="../cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"/>. </p>
+			<p>See<xref href="../cluster_config/gfsh_persist.xml"/>. </p>
 		</section>
 		<section id="section_FF25228E30624E04ACA8784A2183D585">
 			<title>Start the Locator</title>
@@ -99,7 +99,7 @@ mcast-port=0</codeblock>
 						id="ul_95A227C9D8A74EFD95EC09D0B46B99BF">
 						<li id="li_D5C019CFD76F4F69A2DA324746941636">Use the <codeph>gfsh</codeph>
 							command-line utility. See <xref
-								href="../../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
+								href="../../tools_modules/gfsh/chapter_overview.xml"
 								type="concept" format="dita" scope="local"/> for more information on
 							using <codeph>gfsh</codeph>. The syntax for starting the <p>Example
 								commands: </p>

--- a/configuring/running/shutting_down.xml
+++ b/configuring/running/shutting_down.xml
@@ -2,8 +2,9 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="concept_47C4C4F5E59948B694B394B0A57C5ECC">
 	<title>Shutting Down the System</title>
-	<shortdesc>Shut down your <keyword keyref="product_name"/> system by using either <codeph>gfsh</codeph>'s
-			<codeph>shutdown</codeph> command or by shutting down individual members one at a time. </shortdesc>
+	<shortdesc>Shut down your <keyword keyref="product_name"/> system by using either
+			<codeph>gfsh</codeph>'s <codeph>shutdown</codeph> command or by shutting down individual
+		members one at a time. </shortdesc>
 	<conbody>
 		<section id="section_0EB4DDABB6A348BA83B786EEE7C84CF1">
 			<title>Using the shutdown Command</title>
@@ -29,15 +30,15 @@
 			<title>Shutting Down System Members Individually</title>
 			<p>If you are not using persistent regions, you can shut down the distributed system by
 				shutting down each member in the reverse order of their startup. (See <xref
-					href="starting_up.xml#concept_EA4611AE26904770A83F897DFB6D316F" type="concept"
-					format="dita" scope="local"><?xm-replace_text Starting Up Your System?></xref>
-				for the recommended order of member startup.) </p>
+					href="starting_up.xml" type="concept" format="dita" scope="local"
+					><?xm-replace_text Starting Up Your System?></xref> for the recommended order of
+				member startup.) </p>
 			<p>Shut down the distributed system members according to the type of member. For
 				example, use the following mechanisms to shut down members: <ul
 					id="ul_12CC69DA7B8047AFA69CC5F120B66E0F">
 					<li id="li_0C4894CD078B469A869B008331A4FF99">Use the appropriate mechanism to
-						shut down any <keyword keyref="product_name"/>-connected client applications that are running in the
-						distributed system. </li>
+						shut down any <keyword keyref="product_name"/>-connected client applications
+						that are running in the distributed system. </li>
 					<li id="li_534EF2BF81C74B2EB40A3322AD9B8BB3">Shut down any cache servers. To
 						shut down a server, issue the following <codeph>gfsh</codeph> command:
 						<codeblock>gfsh&gt;stop server --name=&lt;...&gt;</codeblock>or

--- a/configuring/running/starting_up.xml
+++ b/configuring/running/starting_up.xml
@@ -10,12 +10,12 @@
 				distributed system, follow these guidelines for member startup: <ul
 					id="ul_5863AF9CB6DB436E81D974ACA90A4C11">
 					<li id="li_FD023619751949E883BE95DFA93888FF">Start locators first. See <xref
-							href="running_the_locator.xml#running_the_locator" type="concept"
+							href="running_the_locator.xml" type="concept"
 							format="dita" scope="local"/> for examples of locator startup commands. </li>
 					<li id="li_F6AFBB5A5A954FCAB0AEDD40C5B13B66">Start cache servers before the rest
 						of your processes unless the implementation requires that other processes be
 						started ahead of them. <xref
-							href="running_the_cacheserver.xml#running_the_cacheserver"
+							href="running_the_cacheserver.xml"
 							type="concept" format="dita" scope="local"/> for examples of server
 						startup commands. </li>
 					<li id="li_533E8FB3517845899892FCD816A3A6A4">If your distributed system uses
@@ -42,12 +42,10 @@
 						exception.</li>
 				</ul>
 			</p>
-			<note>You can optionally override the default timeout period for shutting down
-				individual processes. This override setting must be specified during member startup.
-				See <xref
-					href="shutting_down.xml#concept_47C4C4F5E59948B694B394B0A57C5ECC/section_7CF680CF8A924C57A7052AE2F975DA81"
-					type="section" format="dita" scope="local"
-					><?xm-replace_text Option for System Member Shutdown Behavior?></xref> for
+			<note>You can optionally override the default timeout period for shutting down individual
+				processes. This override setting must be specified during member startup. See <xref
+					href="shutting_down.xml#concept_47C4C4F5E59948B694B394B0A57C5ECC/section_7CF680CF8A924C57A7052AE2F975DA81"/>
+				<?xm-replace_text Option for System Member Shutdown Behavior?> for
 				details. </note>
 		</section>
 		<section id="section_2F8ABBFCE641463C8A8721841407993D">

--- a/configuring/running/startup_shutdown_intro.xml
+++ b/configuring/running/startup_shutdown_intro.xml
@@ -12,9 +12,8 @@
 				dependencies between your system processes. </p>
 			<p>Use the following guidelines to create startup and shutdown procedures and scripts.
 				Some of these instructions use the <xref
-					href="../../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
-					type="concept" format="dita" scope="local"/>.
-			</p>
+					href="../../tools_modules/gfsh/chapter_overview.xml" type="concept"
+					format="dita" scope="local"/>. </p>
 		</section>
 	</conbody>
 </concept>

--- a/developing/book_intro.xml
+++ b/developing/book_intro.xml
@@ -8,7 +8,7 @@
 		data serialization, event handling, delta propagation, transactions, and more. </shortdesc>
 	<conbody>
 		<p>For information about <keyword keyref="product_name"/> REST application development, see
-				<xref href="../geode_rest/book_intro.xml#concept_7628F498DB534A2D8A99748F5DA5DC94"
+				<xref href="../geode_rest/book_intro.xml"
 			/>.</p>
 	</conbody>
 </concept>

--- a/developing/data_serialization/auto_serialization.xml
+++ b/developing/data_serialization/auto_serialization.xml
@@ -50,7 +50,7 @@
 							data:<codeblock>gfsh>configure pdx --auto-serializable-classes=com\.company\.domain\..*</codeblock>
 							By using gfsh, this configuration can propagated across the cluster
 							through the <xref
-								href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+								href="../../configuring/cluster_config/gfsh_persist.xml"
 								>Cluster Configuration Service</xref>. </li>
 						<li>Alternately, in <codeph>cache.xml</codeph>:
 							<codeblock>&lt;!-- Cache configuration configuring auto serialization behavior --&gt;
@@ -110,7 +110,7 @@ Cache c = new CacheFactory()
 							command:<codeblock>gfsh>configure pdx --portable-auto-serializable-classes=com\.company\.domain\..*</codeblock>By
 							using gfsh, this configuration can propagated across the cluster through
 							the <xref
-								href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+								href="../../configuring/cluster_config/gfsh_persist.xml"
 								>Cluster Configuration Service</xref>. </li>
 						<li id="li_D81205CA3BAB451C8D1E28330E68623D">In cache.xml:
 							<codeblock>&lt;!-- Cache configuration configuring auto serialization behavior --&gt;

--- a/developing/data_serialization/data_serialization_options.xml
+++ b/developing/data_serialization/data_serialization_options.xml
@@ -26,7 +26,7 @@
 			</p>
 			<p>
 				<note>If you are storing objects with the <xref
-						href="../../tools_modules/http_session_mgmt/chapter_overview.xml#http_ses_mgmt_mod"
+						href="../../tools_modules/http_session_mgmt/chapter_overview.xml"
 						>HTTP Session Management Modules</xref>, these objects must be serializable
 					since they are serialized before being stored in the region.</note>
 			</p>

--- a/developing/data_serialization/persist_pdx_metadata_to_disk.xml
+++ b/developing/data_serialization/persist_pdx_metadata_to_disk.xml
@@ -12,11 +12,11 @@
 					<li id="li_93C2D3F5BACB4BCCA907BB00B3B74B31">Understand generally how to
 						configure the <keyword keyref="product_name"/> cache. See <xref
 							format="dita"
-							href="../../basic_config/book_intro.xml#basic_config_management"
+							href="../../basic_config/book_intro.xml"
 							scope="local"/>. </li>
 					<li id="li_D8936C294B4149A4813AD952BF74798A">Understand how <keyword
 							keyref="product_name"/> disk stores work. See <xref format="dita"
-							href="../../managing/disk_storage/chapter_overview.xml#disk_storage"
+							href="../../managing/disk_storage/chapter_overview.xml"
 							scope="local" type="concept"/>. </li>
 				</ul>
 			</p>
@@ -39,7 +39,7 @@
 					<li>(Optional) If you later want to rename the PDX types that are persisted to
 						disk, you can do so on your offline disk-stores by executing the <codeph>pdx
 							rename</codeph> command. See <xref
-							href="../../tools_modules/gfsh/command-pages/pdx.xml#concept_bkv_p4f_qq"
+							href="../../tools_modules/gfsh/command-pages/pdx.xml"
 						/>.</li>
 				</ol>
 			</p>
@@ -69,7 +69,7 @@
 							<row>
 								<entry>
 									<xref
-										href="../storing_data_on_disk/storing_data_on_disk.xml#storing_data_on_disk"
+										href="../storing_data_on_disk/storing_data_on_disk.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>

--- a/developing/data_serialization/use_pdx_high_level_steps.xml
+++ b/developing/data_serialization/use_pdx_high_level_steps.xml
@@ -17,13 +17,13 @@
 						options for each object type that you want to serialize using PDX
 						serialization: <ul id="ul_2EC41122D8EF46BDB082A8C7303A133A">
 							<li id="li_6A4BEAF164D0491CB02A92C445F3F2F8"><xref
-									href="auto_serialization.xml#auto_serialization" type="concept"
+									href="auto_serialization.xml" type="concept"
 									format="dita" scope="local"/></li>
 							<li id="li_3CFCF4CC0FF64EA98A08FE0F79DAF28F"><xref scope="local"
-									href="use_pdx_serializer.xml#use_pdx_serializer" type="concept"
+									href="use_pdx_serializer.xml" type="concept"
 									format="dita"/></li>
 							<li id="li_9AD73B4CDACD4DE79D09D4CE5B4141A9"><xref
-									href="use_pdx_serializable.xml#use_pdx_serializable"
+									href="use_pdx_serializable.xml"
 									type="concept" format="dita" scope="local"/>
 							</li>
 						</ul>
@@ -34,20 +34,20 @@
 						following command before starting up your
 						servers:<codeblock>gfsh>configure pdx --read-serialized=true</codeblock> By
 						using gfsh, this configuration can propagated across the cluster through the
-							<xref href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+							<xref href="../../configuring/cluster_config/gfsh_persist.xml"
 							>Cluster Configuration Service</xref>. Alternately, you would need to
 						configure <codeph>pdx read-serialized</codeph> in each server's
 							<codeph>cache.xml</codeph> file. </li>
 					<li id="li_64526767DBE140D2B3C2C51BCAABCEE8">If you are storing any <keyword
 							keyref="product_name"/> data on disk, then you must configure PDX
 						serialization to use persistence. See <xref
-							href="persist_pdx_metadata_to_disk.xml#persist_pdx_metadata_to_disk"
+							href="persist_pdx_metadata_to_disk.xml"
 							type="concept" format="dita" scope="local"/> for more information. </li>
 					<li id="li_88ABDDCDAEBC46ED95A0B570C605E55A">(Optional) Wherever you run
 						explicit application code to retrieve and manage your cached entries, you
 						may want to manage your data objects without using full deserialization. To
 						do this, see <xref scope="local"
-							href="program_application_for_pdx.xml#program_application_for_pdx"
+							href="program_application_for_pdx.xml"
 							type="concept" format="dita"/>. </li>
 				</ol>
 			</p>

--- a/developing/data_serialization/use_pdx_serializable.xml
+++ b/developing/data_serialization/use_pdx_serializable.xml
@@ -118,7 +118,7 @@ public void fromData(PdxReader reader)
 					<li id="li_055ABD507D7440DDAB53AB6EB024EBC2">As needed, configure and program
 						your <keyword keyref="product_name"/> applications to use
 							<codeph>PdxInstance</codeph> for selective object deserialization. See
-							<xref href="program_application_for_pdx.xml#program_application_for_pdx"
+							<xref href="program_application_for_pdx.xml"
 							type="concept" format="dita" scope="local"/>. </li>
 				</ul>
 			</p>

--- a/developing/data_serialization/using_pdx_region_entry_keys.xml
+++ b/developing/data_serialization/using_pdx_region_entry_keys.xml
@@ -17,7 +17,7 @@
 			<p>If you are using PDX serialized objects as region entry keys and you are using
 				persistent regions, then you must configure your PDX disk store to be a different
 				one than the disk store used by the persistent regions. See <xref
-					href="persist_pdx_metadata_to_disk.xml#persist_pdx_metadata_to_disk"
+					href="persist_pdx_metadata_to_disk.xml"
 					type="concept" format="dita" scope="local"/> for information on setting up a PDX
 				disk store. </p>
 		</section>

--- a/developing/distributed_regions/how_distribution_works.xml
+++ b/developing/distributed_regions/how_distribution_works.xml
@@ -8,7 +8,7 @@
 		<section id="section_2F892A4987C547E68CA78067133C2C2C">
 			<note> The management of replicated and distributed regions supplements the general
 				information for managing data regions provided in <xref
-					href="../../basic_config/book_intro.xml#basic_config_management" format="dita"
+					href="../../basic_config/book_intro.xml" format="dita"
 				/>. See also <codeph>com.gemstone.gemfire.cache.PartitionAttributes</codeph>. </note>
 			<p>A distributed region automatically sends entry value updates to remote caches and
 				receives updates from them. <ul id="ul_1D81390D8B064B188B341235A1B9B709">

--- a/developing/distributed_regions/how_region_versioning_works.xml
+++ b/developing/distributed_regions/how_region_versioning_works.xml
@@ -15,8 +15,8 @@
 					Because all updates to a partitioned region are serialized on the primary
 						<keyword keyref="product_name"/> member, all members apply the updates in
 					the same order and consistency is maintained at all times. See <xref
-						href="../partitioned_regions/how_partitioning_works.xml#how_partitioning_works"
-						type="concept" format="dita" scope="local"/>. </p>
+						href="../partitioned_regions/how_partitioning_works.xml" type="concept"
+						format="dita" scope="local"/>. </p>
 			</section>
 			<section id="section_72DFB366C8F14ADBAF2A136669ECAB1E">
 				<title>Replicated Region Consistency</title>

--- a/developing/distributed_regions/managing_distributed_regions.xml
+++ b/developing/distributed_regions/managing_distributed_regions.xml
@@ -8,7 +8,7 @@
 	<conbody>
 		<section id="section_11E9E1B3EB5845D9A4FB226A992B8D0D">
 			<p>Before you begin, understand <xref
-					href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+					href="../../basic_config/book_intro.xml" type="concept"
 					format="dita" scope="local"/>. <ol id="ol_495F354FA0C44D9EB065BD6BBA644799">
 					<li id="li_992440BACB4F40EEBFB0C5B7FDFC4690">Choose the region shortcut setting
 						that most closely matches your region configuration. See

--- a/developing/events/configure_client_server_event_messaging.xml
+++ b/developing/events/configure_client_server_event_messaging.xml
@@ -63,7 +63,7 @@ region1.registerInterestRegex("[a-zA-Z]+_[0-9]+"); </codeblock>
 								</li>
 								<li id="li_253F35CAA44241DC9420F77E8965C580">For highly available
 									event messaging, configure server redundancy. See <xref
-										href="configuring_highly_available_servers.xml#configuring_highly_available_servers"
+										href="configuring_highly_available_servers.xml"
 										format="dita" scope="local"/>. </li>
 								<li id="li_3F23BA50904149539D1A533B27FF940B">To have events enqueued
 									for your clients during client downtime, configure durable

--- a/developing/events/implementing_write_behind_event_handler.xml
+++ b/developing/events/implementing_write_behind_event_handler.xml
@@ -211,7 +211,7 @@ AsyncEventQueue asyncQueue = factory.create("sampleQueue", listener);</codeblock
 						the same ID and configuration settings for each queue configuration.
 							<note>You can ensure other members use the sample configuration by using
 							the cluster configuration service available in gfsh. See <xref
-								href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+								href="../../configuring/cluster_config/gfsh_persist.xml"
 							/>.</note></li>
 					<li id="li_9094768B70D140D5A031B3125710FF52">
 						<p>On each <keyword keyref="product_name"/> member that hosts the

--- a/developing/eviction/configuring_data_eviction.xml
+++ b/developing/eviction/configuring_data_eviction.xml
@@ -37,7 +37,7 @@
 							<li id="li_CEA3645771A14665B8F655386D4DA9BF">Locally destroy the entry. </li>
 							<li id="li_B6662FD5B3E046A282FB13F8E6F3DA8F">Overflow the entry data to
 								disk. See <xref
-									href="../storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+									href="../storing_data_on_disk/chapter_overview.xml"
 									type="concept" format="dita" scope="local"/>. </li>
 						</ul>
 					</li>
@@ -52,7 +52,7 @@
 						follow the guidelines for defining custom classes and, additionally, must
 						implement <codeph>com.gemstone.gemfire.cache.util.ObjectSizer</codeph>. See
 							<xref
-							href="../../basic_config/data_entries_custom_classes/using_custom_classes.xml#using_custom_classes"
+							href="../../basic_config/data_entries_custom_classes/using_custom_classes.xml"
 							type="concept" format="dita" scope="local"/>. </li>
 				</ol>
 			</p>

--- a/developing/eviction/how_eviction_works.xml
+++ b/developing/eviction/how_eviction_works.xml
@@ -9,7 +9,7 @@
 			<p>You configure for eviction based on entry count, percentage of available heap, and
 				absolute memory usage. You also configure what to do when you need to evict: destroy
 				entries or overflow them to disk. See <xref
-					href="../storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+					href="../storing_data_on_disk/chapter_overview.xml"
 					type="concept" format="dita" scope="local"/>. </p>
 			<p>When <keyword keyref="product_name"/> determines that adding or updating an entry would take the region over
 				the specified level, it overflows or removes enough older entries to make room. For

--- a/developing/function_exec/how_function_execution_works.xml
+++ b/developing/function_exec/how_function_execution_works.xml
@@ -21,7 +21,7 @@
 					<li id="li_32D051652A39470BA88184043E4EE044"> On member groups or on a single
 						member within each member group. In <keyword keyref="product_name"/> 7.0,
 						you can organize members into logical member groups. (See <xref
-							href="../../configuring/cluster_config/using_member_groups.xml#concept_5B60087DA11644C49250064BAB8AFFA6"
+							href="../../configuring/cluster_config/using_member_groups.xml"
 							type="concept" format="dita" scope="local"/> for more information.) You
 						can invoke a data independent function on all members in a specified member
 						group (or member groups) or execute the function on only one member of each

--- a/developing/outside_data_sources/chapter_overview.xml
+++ b/developing/outside_data_sources/chapter_overview.xml
@@ -16,12 +16,12 @@
 						data expiration to get rid of old data, and your other data loading
 						applications, which might be prompted by events in the outside data source.
 						See <xref
-							href="../expiration/configuring_data_expiration.xml#configuring_data_expiration"
+							href="../expiration/configuring_data_expiration.xml"
 							type="concept" format="dita" scope="local"/>. </li>
 					<li id="li_C124F8E9A7EA412E9BB5AE75A9E4560D">Write data out to the data source
 						using the cache event handlers, <codeph>CacheWriter</codeph> and
 							<codeph>CacheListener</codeph>. For implementation details, see <xref
-							href="../events/implementing_cache_event_handlers.xml#implementing_cache_event_handlers"
+							href="../events/implementing_cache_event_handlers.xml"
 							type="concept" format="dita" scope="local"/>. <ul
 							id="ul_4F5FC24118874954840B98B91344925C">
 							<li id="li_00B73B07E09D475F98C806D32D6BC353"

--- a/developing/outside_data_sources/how_data_loaders_work.xml
+++ b/developing/outside_data_sources/how_data_loaders_work.xml
@@ -14,7 +14,7 @@
 				cache from an outside data store. To do the reverse operation, writing data from the
 					<keyword keyref="product_name"/> cache to an outside data store, use a cache
 				writer event handler. See <xref
-					href="../events/implementing_cache_event_handlers.xml#implementing_cache_event_handlers"
+					href="../events/implementing_cache_event_handlers.xml"
 					type="concept" format="dita" scope="local"/>. </p>
 			<p>How to install your cache loader depends on the type of region. </p>
 		</section>

--- a/developing/partitioned_regions/colocating_partitioned_region_data.xml
+++ b/developing/partitioned_regions/colocating_partitioned_region_data.xml
@@ -12,7 +12,7 @@
 		<section id="section_131EC040055E48A6B35E981B5C845A65">
 			<note>If you are co-locating data between regions and custom partitioning the data in
 				the regions, all co-located regions must use the same custom partitioning mechanism.
-				See <xref href="using_custom_partition_resolvers.xml#custom_partition_region_data"
+				See <xref href="using_custom_partition_resolvers.xml"
 					type="concept" format="dita" scope="local"/>. </note>
 			<p>Data co-location between partitioned regions generally improves the performance of
 				data-intensive operations. You can reduce network hops for iterative operations on
@@ -28,20 +28,20 @@
 			<ul id="ul_44FD90C4658044AAA46AE58026698337">
 				<li id="li_200F734D659044C4BBD1A919F61005ED">Understand how to configure and create
 					your partitioned regions. See <xref format="dita"
-						href="how_partitioning_works.xml#how_partitioning_works" scope="local"
+						href="how_partitioning_works.xml" scope="local"
 						type="concept"/> and <xref format="dita"
 						href="managing_partitioned_regions.xml#configure_partitioned_regions"
 						scope="local" type="concept"/>. </li>
 				<li id="li_20F7B873685D40D8A1EAC02AEF311815">(Optional) Understand how to
 					custom-partition your data. See <xref format="dita"
-						href="using_custom_partition_resolvers.xml#custom_partition_region_data"/>. </li>
+						href="using_custom_partition_resolvers.xml"/>. </li>
 				<li id="li_B898017E0CA142D6B28832F6495DB702">(Optional) If you want your co-located
 					regions to be highly available, understand how high availability for partitioned
 					regions works. See <xref href="how_pr_ha_works.xml#how_pr_ha_works"
 						type="concept" format="dita" scope="local"/>. </li>
 				<li id="li_1A5BA0D0863640BAA49AB42F38432AEE">(Optional) Understand how to persist
 					your region data. See <xref format="dita"
-						href="../storing_data_on_disk/storing_data_on_disk.xml#storing_data_on_disk"
+						href="../storing_data_on_disk/storing_data_on_disk.xml"
 						scope="local" type="concept"/>. </li>
 			</ul>
 			<p>

--- a/developing/partitioned_regions/configure_pr_single_hop.xml
+++ b/developing/partitioned_regions/configure_pr_single_hop.xml
@@ -21,7 +21,7 @@
 			<step id="step_C5FB37680D754ABBA04483D43916A68E">
 				<cmd>If possible, use a custom data resolver to partition your server region data
 					according to your clients' data use patterns. See <xref
-						href="using_custom_partition_resolvers.xml#custom_partition_region_data"
+						href="using_custom_partition_resolvers.xml"
 						format="dita"><?xm-replace_text Custom-Partition Your Region Data?></xref>.
 					Include the server’s partition resolver implementation in the client’s
 						<codeph>CLASSPATH</codeph>. The server passes the name of the resolver for

--- a/developing/partitioned_regions/managing_partitioned_regions.xml
+++ b/developing/partitioned_regions/managing_partitioned_regions.xml
@@ -7,16 +7,16 @@
 	<conbody>
 		<section id="section_241583D88E244AB6AB5CD05BF55F6A0A">
 			<p>Before you begin, understand <xref format="dita"
-					href="../../basic_config/book_intro.xml#basic_config_management" scope="local"
+					href="../../basic_config/book_intro.xml" scope="local"
 				/>. <ol id="ol_d8392d8d-3759-4a0a-b49f-e20e7a31ec4d">
 					<li id="li_7C97291B588340BEAC4A4E63CAE9ED85">Start your region configuration
 						using one of the <codeph>PARTITION</codeph> region shortcut settings. See
 							<xref format="dita"
-							href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts"
+							href="../../basic_config/data_regions/region_shortcuts.xml"
 							scope="local"/>. </li>
 					<li id="li_900263D8B21A4F1982D219E27AA10F82">If you need high availability for
 						your partitioned region, configure for that. See <xref format="dita"
-							href="configuring_ha_for_pr.xml#configuring_pr_redundancy" scope="local"
+							href="configuring_ha_for_pr.xml" scope="local"
 						/>. </li>
 					<li id="li_548CC86905F34EDA9EC86D145AF600E8">Estimate the amount of space needed
 						for the region. If you use redundancy, this is the max for all primary and

--- a/developing/partitioned_regions/moving_partitioned_data.xml
+++ b/developing/partitioned_regions/moving_partitioned_data.xml
@@ -56,7 +56,7 @@ PartitionRegionHelper.moveData(r, source, destination, 20);</codeblock>See
         <codeph>com.gemstone.gemfire.cache.partition.PartitionRegionHelper.moveData</codeph>
       for more details.</p>
     <p>For more information on partitioned regions and rebalancing, see <xref
-        href="../partitioned_regions/chapter_overview.xml#managing_partitioned_regions">Partitioned
+        href="../partitioned_regions/chapter_overview.xml">Partitioned
         Regions</xref>.</p>
   </body>
 </topic>

--- a/developing/partitioned_regions/rebalancing_pr_data.xml
+++ b/developing/partitioned_regions/rebalancing_pr_data.xml
@@ -13,7 +13,7 @@
 					<li id="li_63A45700885144BA83CCAE32AB013CEA">If the configured partition region
 						redundancy is not satisfied, rebalancing does what it can to recover
 						redundancy. See <xref
-							href="configuring_ha_for_pr.xml#configuring_pr_redundancy" format="dita"
+							href="configuring_ha_for_pr.xml" format="dita"
 						/>. </li>
 					<li id="li_C1289E38524E4075867B732D4553809E">Rebalancing moves the partitioned
 						region data buckets between host members as needed to establish the most
@@ -42,7 +42,7 @@
 							href="rebalancing_pr_data.xml#rebalancing_pr_data/section_495FEE48ED60433BADB7D36C73279C89"
 							type="section" format="dita" scope="local">simulate a rebalance
 							operation</xref>. Type <codeph>help rebalance</codeph> or see <xref
-							href="../../tools_modules/gfsh/command-pages/rebalance.xml#concept_213FDC5574474CE1AC28444DA202E05B"
+							href="../../tools_modules/gfsh/command-pages/rebalance.xml"
 							type="concept" format="dita" scope="local"/> for more information. </li>
 					<li id="li_CF31E2F6944540F0A1B838625E47E153">API call:
 						<codeblock>ResourceManager manager = cache.getResourceManager(); 
@@ -100,7 +100,7 @@ System.out.println(" and create " + results.getTotalBucketCreatesCompleted() + "
 						availability and have configured your region to not automatically recover
 						redundancy after a loss. In this case, <keyword keyref="product_name"/> only
 						restores redundancy when you invoke a rebalance. See <xref
-							href="configuring_ha_for_pr.xml#configuring_pr_redundancy" format="dita"
+							href="configuring_ha_for_pr.xml" format="dita"
 							scope="local"/>. </li>
 					<li id="li_1B3ABCDAA5B341D4B4ADC2C6F19738D9">You have uneven hashing of data.
 						Uneven hashing can occur if your keys do not have a hash code method, which

--- a/developing/partitioned_regions/using_custom_partition_resolvers.xml
+++ b/developing/partitioned_regions/using_custom_partition_resolvers.xml
@@ -30,7 +30,7 @@
 				<ul id="ul_AB0B6A80DFF1409980DE9C77815DDCE1">
 					<li id="li_8029CB1B357B459AB31FAF1DA2740351">Create partitioned regions. See
 							<xref format="dita"
-							href="how_partitioning_works.xml#how_partitioning_works" scope="local"
+							href="how_partitioning_works.xml" scope="local"
 							type="concept"/> and <xref format="dita"
 							href="managing_partitioned_regions.xml#configure_partitioned_regions"
 							scope="local" type="concept"/>. </li>
@@ -112,7 +112,7 @@
 								<codeph>false</codeph> (the default). The number of secondaries must
 							match the number of redundant copies you have defined for the region.
 							See <xref format="dita"
-								href="configuring_ha_for_pr.xml#configuring_pr_redundancy"/>.
+								href="configuring_ha_for_pr.xml"/>.
 								<note>Buckets for a partition are hosted only by the members that
 								have defined the partition name in their
 									<codeph>FixedPartitionAttributes</codeph>. </note>

--- a/developing/query_additional/supported_keywords.xml
+++ b/developing/query_additional/supported_keywords.xml
@@ -74,7 +74,7 @@
 			<property>
 				<proptype>&lt;HINT&gt;</proptype>
 				<propvalue>Keyword that instructs the query engine to prefer certain indexes. </propvalue>
-				<propdesc>See <xref href="../query_index/query_index_hints.xml#topic_cfb_mxn_jq"
+				<propdesc>See <xref href="../query_index/query_index_hints.xml"
 					/></propdesc>
 			</property>
 			<property>

--- a/developing/query_index/creating_an_index.xml
+++ b/developing/query_index/creating_an_index.xml
@@ -26,7 +26,7 @@
 						type="concept" format="dita" scope="local"/> for more information. </li>
 				<li><codeph>createDefinedIndexes</codeph>. Creates multiple indexes that were
 					previously defined using <codeph>defineIndex</codeph>. See <xref
-						href="create_multiple_indexes.xml#topic_omf_pxn_jq"/> for more
+						href="create_multiple_indexes.xml"/> for more
 					information.</li>
 			</ul> The following sections provide examples of index creation: <p><b>Using gfsh:</b>
 				<codeblock>

--- a/developing/query_index/indexing_guidelines.xml
+++ b/developing/query_index/indexing_guidelines.xml
@@ -21,7 +21,7 @@
 				<li>If you are creating multiple indexes on the same region, first define your
 					indexes and then create the indexes all at once to avoid iterating over the
 					region multiple times. See <xref
-						href="create_multiple_indexes.xml#topic_omf_pxn_jq"/> for details.</li>
+						href="create_multiple_indexes.xml"/> for details.</li>
 			</ul>
 		</section>
 		<section id="section_A8AFAA243B5C43DD9BB9F9235A48AF53">
@@ -46,7 +46,7 @@
 					could have an index on <codeph>qty</codeph> applied for efficiency. However,
 						<codeph>NOT(qty &lt; 10)</codeph> could not have the same index applied. </li>
 				<li>Whenever possible, provide a hint to allow the query engine to prefer a specific
-					index. See <xref href="query_index_hints.xml#topic_cfb_mxn_jq"/></li>
+					index. See <xref href="query_index_hints.xml"/></li>
 			</ul>
 		</section>
 	</conbody>

--- a/developing/query_select/the_where_clause.xml
+++ b/developing/query_select/the_where_clause.xml
@@ -115,7 +115,7 @@ SELECT DISTINCT * FROM /exampleRegion p WHERE p.position1.getSecId() = '1'
 			<p> To create indexes for region joins you create single-region indexes for both sides
 				of the join condition. These are used during query execution for the join condition.
 				Partitioned regions do not support region joins. For more information on indexes,
-				see <xref href="../query_index/query_index.xml#indexing" type="concept"
+				see <xref href="../query_index/query_index.xml" type="concept"
 					format="dita" scope="local"/>. </p>
 			<b>Examples:</b>
 			<table id="table_76F4DC6F1FD343748579D76D7D7BEFE3">

--- a/developing/querying_basics/running_a_query.xml
+++ b/developing/querying_basics/running_a_query.xml
@@ -73,7 +73,7 @@
 					</li>
 				</ul><note>You can also perform queries using the gfsh <cmdname>query</cmdname>
 					command. See <xref
-						href="../../tools_modules/gfsh/command-pages/query.xml#concept_89A129F729DF4D3B9056C8D9016AA760"
+						href="../../tools_modules/gfsh/command-pages/query.xml"
 					/>.</note>
 			</p>
 		</section>

--- a/developing/region_options/dynamic_region_creation.xml
+++ b/developing/region_options/dynamic_region_creation.xml
@@ -13,7 +13,7 @@
     <p>Pivotal recommends that you use functions to create regions dynamically in your application,
       as described in this topic.</p>
     <p>For a complete discussion of using <keyword keyref="product_name"/> functions, see <xref
-        href="../function_exec/chapter_overview.xml#function_exec"/>. Functions use the
+        href="../function_exec/chapter_overview.xml"/>. Functions use the
         <apiname>com.gemstone.gemfire.cache.execute.FunctionService</apiname> class. </p>
     <p>For example, the following Java classes define and use a function for dynamic region
       creation:</p>

--- a/developing/storing_data_on_disk/chapter_overview.xml
+++ b/developing/storing_data_on_disk/chapter_overview.xml
@@ -7,10 +7,10 @@
 		data from your cache. </shortdesc>
 	<conbody>
 		<note>This supplements the general steps for managing data regions provided in <xref
-				href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+				href="../../basic_config/book_intro.xml" type="concept"
 				format="dita" scope="local"/>. </note>
 		<p>All disk storage uses <keyword keyref="product_name_long"/><xref
-				href="../../managing/disk_storage/chapter_overview.xml#disk_storage" type="concept"
+				href="../../managing/disk_storage/chapter_overview.xml" type="concept"
 				format="dita" scope="local"/>. </p>
 	</conbody>
 </concept>

--- a/developing/storing_data_on_disk/how_persist_overflow_work.xml
+++ b/developing/storing_data_on_disk/how_persist_overflow_work.xml
@@ -17,7 +17,7 @@
 					keyref="product_name"/> disk stores. For any disk option, you can specify the
 				name of the disk store to use or use the <keyword keyref="product_name"/> default
 				disk store. See <xref
-					href="../../managing/disk_storage/chapter_overview.xml#disk_storage"
+					href="../../managing/disk_storage/chapter_overview.xml"
 					type="concept" format="dita" scope="local"/>. </p>
 		</section>
 		<section id="section_78F2D1820B6C48859A0E5411CE360105">
@@ -48,7 +48,7 @@
 				only on disk and some on disk and in memory. The disk data can be used at member
 				startup to populate the same region. </p>
 			<p>See <xref
-					href="../../managing/disk_storage/how_startup_works_in_system_with_disk_stores.xml#how_startup_works_in_system_with_disk_stores"
+					href="../../managing/disk_storage/how_startup_works_in_system_with_disk_stores.xml"
 					type="concept" format="dita" scope="local"/> for information about the startup
 				process with persistent data. </p>
 		</section>

--- a/developing/transactions/working_with_transactions.xml
+++ b/developing/transactions/working_with_transactions.xml
@@ -18,7 +18,7 @@
         <codeblock>Cache c = CacheFactory.getInstance(system) c.setCopyOnRead(true);</codeblock>The
         copy-on-read attribute and the operations affected by the attribute setting are discussed in
         detail in <xref
-          href="../../basic_config/data_entries_custom_classes/managing_data_entries.xml#managing_data_entries"
+          href="../../basic_config/data_entries_custom_classes/managing_data_entries.xml"
         />.</p>
     </conbody>
   </concept>
@@ -196,7 +196,7 @@ r.put("stringBuf", s); cTxMgr.commit();</codeblock></p>
             listener callbacks - local and remote - are triggered after the transaction commits. The
             system sends the conflated transaction events, in the order they were stored. </li>
         </ul>For more information on writing cache event handlers, see <xref
-          href="../events/implementing_cache_event_handlers.xml#implementing_cache_event_handlers"
+          href="../events/implementing_cache_event_handlers.xml"
         />.</p>
     </conbody>
   </concept>

--- a/geode-book/master_middleman/source/subnavs/_dita_subnav_template.erb
+++ b/geode-book/master_middleman/source/subnavs/_dita_subnav_template.erb
@@ -229,7 +229,7 @@
     <span class="topic"><span class=""><a class="" href="/docs/basic_config/data_entries_custom_classes/managing_data_entries.html">Managing Data Entries</a></span></span>
                                     </li>
                                     <li>
-    <span class="topic"><span class=""><a class="" href="/docs/basic_config/data_entries_custom_classes/using_custom_classes.html#using_custom_classes">Requirements for Using Custom Classes in Data Caching</a></span></span>
+    <span class="topic"><span class=""><a class="" href="/docs/basic_config/data_entries_custom_classes/using_custom_classes.html">Requirements for Using Custom Classes in Data Caching</a></span></span>
                                     </li>
                                 </ul>
                                 </span>

--- a/geode-book/master_middleman/source/subnavs/geode_subnav.erb
+++ b/geode-book/master_middleman/source/subnavs/geode_subnav.erb
@@ -224,7 +224,7 @@
 <span class="topic"><span class=""><a class="" href="/docs/basic_config/data_entries_custom_classes/managing_data_entries.html">Managing Data Entries</a></span></span>
                                 </li>
                                 <li>
-<span class="topic"><span class=""><a class="" href="/docs/basic_config/data_entries_custom_classes/using_custom_classes.html#using_custom_classes">Requirements for Using Custom Classes in Data Caching</a></span></span>
+<span class="topic"><span class=""><a class="" href="/docs/basic_config/data_entries_custom_classes/using_custom_classes.html">Requirements for Using Custom Classes in Data Caching</a></span></span>
                                 </li>
                             </ul>
                             </span>

--- a/geode_rest/develop_rest_apps.xml
+++ b/geode_rest/develop_rest_apps.xml
@@ -21,7 +21,7 @@
       <p>You cannot create or delete the regions themselves with the REST APIs, but you can work
         with the data stored within predefined <keyword keyref="product_name"/> regions. Use the
           <xref
-          href="../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
+          href="../tools_modules/gfsh/chapter_overview.xml"
           >gfsh</xref> command utility to add, configure or delete regions in your <keyword
           keyref="product_name"/> deployment. Any additions or modifications to regions made through
           <codeph>gfsh</codeph> are then accessible by the REST APIs. </p>

--- a/geode_rest/setup_config.xml
+++ b/geode_rest/setup_config.xml
@@ -41,7 +41,7 @@
         <li>http-service-ssl-truststore</li>
         <li>http-service-ssl-truststore-password</li>
       </ul>
-      <p dir="ltr">See <xref href="../managing/security/ssl_overview.xml#ssl"/> for details on
+      <p dir="ltr">See <xref href="../managing/security/ssl_overview.xml"/> for details on
         configuring these parameters.</p>
       <p dir="ltr">The above parameters apply to all HTTP services hosted on the configured server,
         which can include the following:</p>
@@ -68,7 +68,7 @@
         <substeps id="substeps_pgr_x5p_y4">
           <substep>
             <cmd>Start up a locator running the <xref
-                href="../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl">cluster configuration
+                href="../configuring/cluster_config/gfsh_persist.xml">cluster configuration
                 service</xref> (enabled by default). For example: </cmd>
             <info>
               <codeblock>gfsh>start locator --name=locator1</codeblock>

--- a/getting_started/15_minute_quickstart_gfsh.xml
+++ b/getting_started/15_minute_quickstart_gfsh.xml
@@ -23,7 +23,7 @@
 					<i>gfsh</i> (pronounced "gee-fish") provides a single, intuitive command-line
 					interface from which you can launch, manage, and monitor <keyword
 						keyref="product_name_long"/> processes, data, and applications. See <xref
-						href="../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
+						href="../tools_modules/gfsh/chapter_overview.xml"
 					/>. </p>
 				<p>The <i>locator</i> is a <keyword keyref="product_name_long"/> process that tells
 					new, connecting members where running members are located and provides load
@@ -31,9 +31,9 @@
 					s used for monitoring and managing of a <keyword keyref="product_name"/>
 					cluster. The cluster configuration service uses locators to persist and
 					distribute cluster configurations to cluster members. See <xref
-						href="../configuring/running/running_the_locator.xml#running_the_locator"/>
+						href="../configuring/running/running_the_locator.xml"/>
 					and <xref
-						href="../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+						href="../configuring/cluster_config/gfsh_persist.xml"
 					/>.</p>
 				<ol id="ol_E7093B61F4644E598DB4FF12FCBFC939">
 					<li id="li_9E7D31E90C89499D9C8A89A4878B4C45">Create a scratch working directory
@@ -83,7 +83,7 @@ Cluster configuration service is up and running.
 					tool. <keyword keyref="product_name"/> Pulse is a Web Application that provides
 					a graphical dashboard for monitoring vital, real-time health and performance of
 						<keyword keyref="product_name"/> clusters, members, and regions. See <xref
-						href="../tools_modules/pulse/chapter_overview.xml#concept_600D5DC7303548BB96F5E3D1941C77C2"
+						href="../tools_modules/pulse/chapter_overview.xml"
 					/>.<codeblock>gfsh&gt;start pulse
 Launched <keyword keyref="product_name"/> Pulse</codeblock>This
 					command launches Pulse and automatically connects you to the JMX Manager running
@@ -100,7 +100,7 @@ Launched <keyword keyref="product_name"/> Pulse</codeblock>This
 						keyref="product_name"/> server is used primarily for hosting long-lived data
 					regions and for running standard <keyword keyref="product_name"/> processes such
 					as the server in a client/server configuration. See <xref
-						href="../configuring/running/running_the_cacheserver.xml#running_the_cacheserver"
+						href="../configuring/running/running_the_cacheserver.xml"
 					/>.</p>
 				<p>Start the cache server:
 					<codeblock>gfsh&gt;start server --name=server1 --server-port=40411
@@ -206,7 +206,7 @@ Result
 one</b></codeblock><p>Note
 							that the result displays the values for the two data entries you created
 							with the <cmdname>put</cmdname> commands.</p><p>See <xref
-								href="../basic_config/data_entries_custom_classes/chapter_overview.xml#setting_distributed_properties"
+								href="../basic_config/data_entries_custom_classes/chapter_overview.xml"
 							/>.</p></li>
 					<li>Stop the cache server using the following
 						command:<codeblock>gfsh>stop server --name=server1
@@ -237,7 +237,7 @@ one</b></codeblock><p>Because
 							Note that the result displays the values for the two data entries you
 							created prior to stopping the server with the <cmdname>put</cmdname>
 							commands.</p><p>See <xref
-								href="../basic_config/data_entries_custom_classes/chapter_overview.xml#setting_distributed_properties"
+								href="../basic_config/data_entries_custom_classes/chapter_overview.xml"
 							/>.</p><p>See <xref
 								href="../basic_config/data_regions/chapter_overview.xml#data_regions"
 							/></p></li>
@@ -466,7 +466,7 @@ NEXT_STEP_NAME : END
 							<codeph>gfsh</codeph> session, stop the cluster:
 							<codeblock>gfsh&gt;shutdown --include-locators=true</codeblock><p>See
 								<xref
-								href="../tools_modules/gfsh/command-pages/shutdown.xml#concept_249C98CFF0BF4BCCA7778AE2D751F52E"
+								href="../tools_modules/gfsh/command-pages/shutdown.xml"
 							/>. </p>
 					</li>
 					<li id="li_8DC6EE8843E14C449500A44CBF4091FA">When prompted, type 'Y' to confirm

--- a/getting_started/gemfire_tutorial/other_features.xml
+++ b/getting_started/gemfire_tutorial/other_features.xml
@@ -31,7 +31,7 @@
 			<p>Suppose you want to show all people who have someone listed as a friend. <keyword
 					keyref="product_name"/> supports querying region contents using Object Query
 				Language (OQL). See <xref
-					href="../../developing/querying_basics/chapter_overview.xml#querying_with_oql"
+					href="../../developing/querying_basics/chapter_overview.xml"
 					type="concept" format="dita" scope="local"/> and the Javadocs for the
 					<codeph>com.gemstone.gemfire.cache.query</codeph> package for more information.
 				To find all people who have listed Ethan as a friend: </p>
@@ -60,7 +60,7 @@ Set&lt;String&gt; authors = new HashSet&lt;String&gt;();
 authors.add("Ethan");
 FunctionService.onRegion(people).withFilter(authors).execute(spellcheck);</codeblock>
 			<p>For more information on function execution, see <xref
-					href="../../developing/function_exec/chapter_overview.xml#function_exec"
+					href="../../developing/function_exec/chapter_overview.xml"
 					format="dita"/>. </p>
 		</section>
 		<section id="section_93057612655A4C7C900B4321D6E95EFC">
@@ -83,9 +83,9 @@ FunctionService.onRegion(people).withFilter(authors).execute(spellcheck);</codeb
 				when your heap is getting full. </p>
 			<p>Rather than lose the values completely, you can configure the region to overflow
 				values onto disk. </p>
-			<p>See <xref href="../../developing/eviction/chapter_overview.xml#eviction"
+			<p>See <xref href="../../developing/eviction/chapter_overview.xml"
 					type="concept" format="dita" scope="local"/> and <xref
-					href="../../developing/expiration/chapter_overview.xml#expiration"
+					href="../../developing/expiration/chapter_overview.xml"
 					type="concept" format="dita" scope="local"/> for more information. </p>
 		</section>
 	</conbody>

--- a/getting_started/gemfire_tutorial/running_tutorial.xml
+++ b/getting_started/gemfire_tutorial/running_tutorial.xml
@@ -646,7 +646,7 @@ ubuntu.local[1099]</codeblock>If
   &lt;/region>
 &lt;/cache></codeblock><p>For
 						more information about using gfsh and cluster configurations, see <xref
-							href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+							href="../../configuring/cluster_config/gfsh_persist.xml"
 						/>.</p></li>
 			</ol>
 		</section>

--- a/getting_started/querying_quick_reference.xml
+++ b/getting_started/querying_quick_reference.xml
@@ -7,7 +7,7 @@
 	<refbody>
 		<section id="section_AFAD97A4BA2D45CF91ED1525A54DDFD6">
 			<p> For additional information on <keyword keyref="product_name"/> querying, see <xref
-					href="../developing/querying_basics/chapter_overview.xml#querying_with_oql"
+					href="../developing/querying_basics/chapter_overview.xml"
 					type="concept" format="dita" scope="local"/>. </p>
 			<ul id="ul_183000E6AAB94F73A2C3B4A12B57DEC5">
 				<li id="li_03FB835D6BEE421F8350E7C57FB2353E">
@@ -88,9 +88,9 @@
 				<li id="li_A77B8D3B2B5448ECAF1BE6E9BD856F4A"><keyword keyref="product_name"/>
 					querying APIs </li>
 				<li id="li_2FD8AE2C7AF242D99679891C8BF0FB6D"><xref
-						href="../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
+						href="../tools_modules/gfsh/chapter_overview.xml"
 						>gfsh</xref> command-line interface; in particular the <xref
-						href="../tools_modules/gfsh/command-pages/query.xml#concept_89A129F729DF4D3B9056C8D9016AA760"
+						href="../tools_modules/gfsh/command-pages/query.xml"
 						>query</xref> command </li>
 				<li>REST API <xref href="../geode_rest/rest_queries.xml#concept_mmg_d35_m4">query
 						endpoints</xref></li>
@@ -371,7 +371,7 @@ SelectResults results = (SelectResults)query.execute(params);
  &lt;entry&gt;
 </codeblock>
 				For more details on indexes, see <xref
-					href="../developing/query_index/query_index.xml#indexing" type="concept"
+					href="../developing/query_index/query_index.xml" type="concept"
 					format="dita" scope="local"><?xm-replace_text Working with Indexes?></xref>.
 			</p>
 		</section>

--- a/getting_started/system_requirements/modules_system_requirements.xml
+++ b/getting_started/system_requirements/modules_system_requirements.xml
@@ -26,7 +26,7 @@
 								<entry colname="col1">tc Server </entry>
 								<entry colname="col02">2.5 </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml#http_tc_server"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>
@@ -34,7 +34,7 @@
 								<entry colname="col1">tc Server </entry>
 								<entry colname="col02">2.6 </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml#http_tc_server"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>
@@ -42,7 +42,7 @@
 								<entry colname="col1">tc Server </entry>
 								<entry colname="col02">2.7 </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml#http_tc_server"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>
@@ -50,28 +50,28 @@
 								<entry colname="col1">tc Server </entry>
 								<entry colname="col02">2.8 </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml#http_tc_server"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml"
 										type="concept" format="dita" scope="local"/></entry>
 							</row>
 							<row>
 								<entry colname="col1">tc Server</entry>
 								<entry colname="col02">2.9</entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml#http_tc_server"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml"
 										type="concept" format="dita" scope="local"/></entry>
 							</row>
 							<row>
 								<entry colname="col1">tc Server</entry>
 								<entry colname="col02">3.0</entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml#http_tc_server"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_tcserver.xml"
 										type="concept" format="dita" scope="local"/></entry>
 							</row>
 							<row>
 								<entry colname="col1">Tomcat </entry>
 								<entry colname="col02">6.0 </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_tomcat.xml#http_tomcat_first"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_tomcat.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>
@@ -79,7 +79,7 @@
 								<entry colname="col1">Tomcat </entry>
 								<entry colname="col02">7.0 </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_tomcat.xml#http_tomcat_first"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_tomcat.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>
@@ -87,7 +87,7 @@
 								<entry colname="col1">WebLogic </entry>
 								<entry colname="col02">11g (10.3.x) </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_weblogic.xml#http_weblogic_first"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_weblogic.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>
@@ -95,7 +95,7 @@
 								<entry colname="col1">WebSphere </entry>
 								<entry colname="col02">7, 8 </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_weblogic.xml#http_weblogic_first"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_weblogic.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>
@@ -103,7 +103,7 @@
 								<entry colname="col1">JBoss </entry>
 								<entry colname="col02">5, 6, 7 </entry>
 								<entry colname="col2"><xref
-										href="../../tools_modules/http_session_mgmt/session_mgmt_weblogic.xml#http_weblogic_first"
+										href="../../tools_modules/http_session_mgmt/session_mgmt_weblogic.xml"
 										type="concept" format="dita" scope="local"/>
 								</entry>
 							</row>
@@ -133,7 +133,7 @@
 			</p>
 			<p otherprops="webhelp_only">For more information on using the Hibernate Module, see
 					<xref
-					href="../../tools_modules/hibernate_cache/chapter_overview.xml#hib_cac_mod"
+					href="../../tools_modules/hibernate_cache/chapter_overview.xml"
 					type="concept" format="dita" scope="local"/>. </p>
 		</section>
 	</conbody>

--- a/managing/disk_storage/backup_restore_disk_store.xml
+++ b/managing/disk_storage/backup_restore_disk_store.xml
@@ -211,7 +211,7 @@ The backup may be incomplete. The following disk stores are not online:
 					</li>
 					<li id="li_5C0E32CB0B8F476E9691C54335BF625F">Deployed JAR files that you
 						deployed using the gfsh <xref
-							href="../../tools_modules/gfsh/command-pages/deploy.xml#concept_6B38CB283BC048778A8E3908C1BDF221"
+							href="../../tools_modules/gfsh/command-pages/deploy.xml"
 							type="concept" format="dita" scope="local">deploy</xref> command. </li>
 					<li id="li_6121E8AF44F7467AB05494A41339F1D6">Configuration files from the member
 						startup. <ul id="ul_743FF442E72540C681CA607358114D97">

--- a/managing/disk_storage/managing_disk_stores_cmds.xml
+++ b/managing/disk_storage/managing_disk_stores_cmds.xml
@@ -6,7 +6,7 @@
 		<section id="section_4AFD4B9EECDA448BA5235FB1C32A48F1">
 			<p>You can manage your disk stores using the gfsh command-line tool. For more
 				information on <codeph>gfsh</codeph> commands, see <xref scope="local"
-					href="../../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
+					href="../../tools_modules/gfsh/chapter_overview.xml"
 					type="concept" format="dita"
 					/> and
 					<xref

--- a/managing/disk_storage/operation_logs.xml
+++ b/managing/disk_storage/operation_logs.xml
@@ -14,7 +14,7 @@
 				required for startup, if it is available, it will improve startup performance by
 				allowing <keyword keyref="product_name"/> to load the entry values in the background
 				after the entry keys are loaded. See <xref
-					href="how_startup_works_in_system_with_disk_stores.xml#how_startup_works_in_system_with_disk_stores"
+					href="how_startup_works_in_system_with_disk_stores.xml"
 					type="concept" format="dita" scope="local"/>. </p>
 			<p>When an operation log is full, <keyword keyref="product_name"/> automatically closes
 				it and creates a new log with the next sequence number. This is called <i>oplog

--- a/managing/disk_storage/shutting_down_system_with_disk_stores.xml
+++ b/managing/disk_storage/shutting_down_system_with_disk_stores.xml
@@ -22,11 +22,11 @@
 				synchronizes all of the online region data stores before shutdown. This means every
 				disk store has the most recent data and does not require updates from other members
 				at startup. See also <xref scope="local"
-					href="how_startup_works_in_system_with_disk_stores.xml#how_startup_works_in_system_with_disk_stores"
+					href="how_startup_works_in_system_with_disk_stores.xml"
 					type="concept" format="dita"
 					><?xm-replace_text How Startup and Shutdown Work with Disk Stores?></xref> and
 					<xref
-					href="../../tools_modules/gfsh/command-pages/shutdown.xml#concept_249C98CFF0BF4BCCA7778AE2D751F52E"
+					href="../../tools_modules/gfsh/command-pages/shutdown.xml"
 					type="concept" format="dita" scope="local"><?xm-replace_text shutdown?></xref>.
 			</p>
 		</section>

--- a/managing/disk_storage/using_disk_stores.xml
+++ b/managing/disk_storage/using_disk_stores.xml
@@ -36,7 +36,7 @@
 		<section id="section_0CD724A12EE4418587046AAD9EEC59C5">
 			<title>Design Your Disk Stores</title>
 			<p>Before you begin, you should understand <keyword keyref="product_name"/>
-				<xref href="../../basic_config/book_intro.xml#basic_config_management"
+				<xref href="../../basic_config/book_intro.xml"
 					type="concept" format="dita" scope="local"/>. <ol
 					id="ol_4C758B1E5FE34E3499AF2918DB68B917">
 					<li id="li_9759033182A44184A17BC5D950B1D3B1">Work with your system designers and
@@ -183,7 +183,7 @@
 					you have the cluster configuration service enabled, when you create a disk store
 					in <codeph>gfsh</codeph>, you can share the disk store's configuration with the
 					rest of cluster. See <xref
-						href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"
+						href="../../configuring/cluster_config/gfsh_persist.xml"
 					/>.</note>
 			</p>
 			<table frame="all" id="table_90850e59-9601-4714-a305-1f2ba839c04b">

--- a/managing/heap_use/controlling_heap_use.xml
+++ b/managing/heap_use/controlling_heap_use.xml
@@ -58,7 +58,7 @@
 						participate in heap eviction and set their
 							<codeph>eviction-attributes</codeph> to
 							<codeph>lru-heap-percentage</codeph>. See <xref
-							href="../../developing/eviction/chapter_overview.xml#eviction"
+							href="../../developing/eviction/chapter_overview.xml"
 							type="concept" format="dita" scope="local"/>. The regions you configure
 						for eviction should have enough data activity for the evictions to be useful
 						and should contain data your application can afford to delete or offload to

--- a/managing/logging/how_logging_works.xml
+++ b/managing/logging/how_logging_works.xml
@@ -35,6 +35,6 @@
 			within the JMX Management &amp; Monitoring system. These appenders do not currently
 			support configuration within a <filepath>log4j2.xml</filepath> config file.</p>
 		<p>Advanced users may wish to define their own <filepath>log4j2.xml</filepath>. See <xref
-				href="configuring_log4j2.xml#concept_c4k_1qf_jq"/> for more details.</p>
+				href="configuring_log4j2.xml"/> for more details.</p>
 	</conbody>
 </concept>

--- a/managing/logging/logging_categories.xml
+++ b/managing/logging/logging_categories.xml
@@ -277,7 +277,7 @@ udp-send-buffer-size="65535"</codeblock>
 			</p>
 			<p><note><keyword keyref="product_name"/> no longer supports setting system properties
 					for VERBOSE logging. To enable VERBOSE logging, see <xref
-						href="configuring_log4j2.xml#concept_c4k_1qf_jq"/>
+						href="configuring_log4j2.xml"/>
 				</note>.</p>
 		</section>
 	</conbody>

--- a/managing/logging/migrate_log4j.xml
+++ b/managing/logging/migrate_log4j.xml
@@ -38,7 +38,7 @@ import org.apache.logging.log4j.Logger;</codeblock>
             </step>
             <step>
                 <cmd>Optionally, optimize the Log4j configuration for your GemFire deployment. See <xref
-                        href="configuring_log4j2.xml#concept_c4k_1qf_jq"/>.</cmd>
+                        href="configuring_log4j2.xml"/>.</cmd>
             </step>
         </steps>
     </taskbody>

--- a/managing/logging/setting_up_logging.xml
+++ b/managing/logging/setting_up_logging.xml
@@ -7,7 +7,7 @@
 	<conbody>
 		<section id="section_35F8A9028A91441785BCACD6CD40A498">
 			<p>Before you begin, make sure you understand <xref
-					href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+					href="../../basic_config/book_intro.xml" type="concept"
 					format="dita" scope="local"/>. <ol id="ol_BA9F16EB6E5A4D2D8CB65E26B9DDA306">
 					<li id="li_203ADCB6282B4D93B3CC1ECB8066DB31">Run a time synchronization service
 						such as NTP on all <keyword keyref="product_name"/> host machines. This is the only way to produce

--- a/managing/management/jmx_manager_node.xml
+++ b/managing/management/jmx_manager_node.xml
@@ -10,9 +10,9 @@
 		<body>
 			<p>You need to have a JMX Manager started in your distributed system in order to use
 					<keyword keyref="product_name"/> management and monitoring tools such as <xref
-					href="../../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
+					href="../../tools_modules/gfsh/chapter_overview.xml"
 					type="concept" format="dita" scope="local">gfsh</xref> and <xref
-					href="../../tools_modules/pulse/chapter_overview.xml#concept_600D5DC7303548BB96F5E3D1941C77C2"
+					href="../../tools_modules/pulse/chapter_overview.xml"
 					type="concept" format="dita" scope="local"><keyword keyref="product_name"/>
 					Pulse</xref>. </p>
 			<p>

--- a/managing/management/management_system_overview.xml
+++ b/managing/management/management_system_overview.xml
@@ -160,14 +160,14 @@
 						debugging and deployment of <keyword keyref="product_name"/> applications.
 						It features context sensitive help, scripting and the ability to invoke any
 						commands from within the application using a simple API. See <xref
-							href="../../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
+							href="../../tools_modules/gfsh/chapter_overview.xml"
 							type="concept" format="dita" scope="local">gfsh</xref>. </li>
 					<li id="li_04AA96ADE1744E52AF279D554A2E77D1"><b><keyword keyref="product_name"/>
 							Pulse</b>. Easy-to-use, browser-based dashboard for monitoring <keyword
 							keyref="product_name"/> deployments. <keyword keyref="product_name"/>
 						Pulse provides an integrated view of all <keyword keyref="product_name"/>
 						members within a distributed system. See <xref scope="local"
-							href="../../tools_modules/pulse/chapter_overview.xml#concept_600D5DC7303548BB96F5E3D1941C77C2"
+							href="../../tools_modules/pulse/chapter_overview.xml"
 							type="concept" format="dita"/>. </li>
 					<li id="li_F9AFCCAD9E1A409E9C67B8ADD68ED5A2"><b>Pulse Data Browser</b>. This
 							<keyword keyref="product_name"/> Pulse utility provides a graphical

--- a/managing/management/mm_overview.xml
+++ b/managing/management/mm_overview.xml
@@ -38,7 +38,7 @@
       <p>gfsh runs in its own shell, or you can <xref
           href="../../tools_modules/gfsh/os_command_line_execution.xml#topic_fpf_y1g_tp">execute
           gfsh commands directly from the OS command line</xref>. gfsh can interact with remote
-        systems <xref href="../../configuring/cluster_config/gfsh_remote.xml#task_nyb_mhn_44">using
+        systems <xref href="../../configuring/cluster_config/gfsh_remote.xml">using
           the http protocol</xref>. You can also <xref
           href="../../tools_modules/gfsh/command_scripting.xml#concept_9B2F7550F16C4717831AD40A56922259"
           >write scripts that run in a gfsh shell</xref> to automate system start up. </p>
@@ -57,7 +57,7 @@
         <li><filepath>cluster.properties</filepath> file shared by the cluster</li>
         <li>Deployed jar files containing application Java classes. </li>
       </ul>
-      <p>See <xref href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl"/> and
+      <p>See <xref href="../../configuring/cluster_config/gfsh_persist.xml"/> and
           <xref
           href="../../configuring/cluster_config/gfsh_config_troubleshooting.xml#concept_ylt_2cb_y4"
         /> for additional details on gfsh cluster configuration files.</p>
@@ -88,7 +88,7 @@
       <p><keyword keyref="product_name"/>'s implementation of JMX is industry-standard and friendly
         to generic JMX clients. You can monitor or manage the distributed system by using any
         third-party tool that is compliant with JMX. For example, JConsole.</p>
-      <p>See <xref href="management_and_monitoring.xml#concept_28D17783155A4E4EA32526CFB152A13F"
+      <p>See <xref href="management_and_monitoring.xml"
         /></p>
     </section>
     <section>
@@ -108,7 +108,7 @@
           <keyword keyref="product_name"/> JMX manager to provide a complete view of your <keyword
           keyref="product_name"/> deployment. </p>
       <p>See <xref
-          href="../../tools_modules/pulse/chapter_overview.xml#concept_600D5DC7303548BB96F5E3D1941C77C2"
+          href="../../tools_modules/pulse/chapter_overview.xml"
         />.</p>
     </section>
     <section>
@@ -117,7 +117,7 @@
         gfsh to connect to <keyword keyref="product_name"/>, and then launch JConsole with a gfsh
         command. The JConsole application allows you to browse MBeans, attributes, operations, and
         notifications. See <xref
-          href="gemfire_mbeans_jconsole.xml#concept_492532E145834248997BD23BCAC7AD45"/>. </p>
+          href="gemfire_mbeans_jconsole.xml"/>. </p>
     </section>
   </conbody>
 </concept>

--- a/managing/monitor_tune/monitoring_tools.xml
+++ b/managing/monitor_tune/monitoring_tools.xml
@@ -31,7 +31,7 @@
 		  locator, use this command: 
 		  <codeblock>gemfire status-locator [-dir=locatorDir]</codeblock>See 
 		  <xref format="dita"
-			href="../../deploying/topics/running_the_locator.xml#running_the_locator"
+			href="../../deploying/topics/running_the_locator.xml"
 			scope="local" type="concept"><?xm-replace_text vFabric GemFire Locator Process?></xref>
 		  
 		  <p> 
@@ -41,7 +41,7 @@
 		  cache server, use this command: 
 		  <codeblock>cacheserver status [-dir=workingDir]</codeblock> See 
 		  <xref format="dita"
-			href="../../deploying/topics/running_the_cacheserver.xml#running_the_cacheserver"
+			href="../../deploying/topics/running_the_cacheserver.xml"
 			scope="local" type="concept"><?xm-replace_text vFabric GemFire cacheserver?></xref>
 		  
 		</li> 

--- a/managing/monitor_tune/montitoring_tools_apis.xml
+++ b/managing/monitor_tune/montitoring_tools_apis.xml
@@ -81,7 +81,7 @@
 			 This can be configured through the 
 			 <codeph>CacheVmConfig</codeph> interface. See also 
 			 <xref
-			  href="../../deploying/topics/running_the_cacheserver.xml#running_the_cacheserver"
+			  href="../../deploying/topics/running_the_cacheserver.xml"
 			  format="dita"><?xm-replace_text vFabric GemFire cacheserver?></xref>. 
 		  </li> 
 		</ul> 

--- a/managing/monitor_tune/multicast_communication.xml
+++ b/managing/monitor_tune/multicast_communication.xml
@@ -7,11 +7,11 @@
 
 	<conbody>
 		<p>Before you begin, you should understand <keyword keyref="product_name"/> <xref
-				href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+				href="../../basic_config/book_intro.xml" type="concept"
 				format="dita" scope="local"
 				><?xm-replace_text Basic Configuration and Programming?></xref>. See also the
 			general communication tuning and UDP tuning covered in <xref
-				href="socket_communication.xml#socket_comm" type="concept" format="dita"
+				href="socket_communication.xml" type="concept" format="dita"
 				scope="local"><?xm-replace_text Socket Communication?></xref> and <xref
 				href="udp_communication.xml#udp_comm" type="concept" format="dita" scope="local"
 				><?xm-replace_text UDP Communication?></xref>. </p>

--- a/managing/monitor_tune/performance_controls.xml
+++ b/managing/monitor_tune/performance_controls.xml
@@ -6,7 +6,7 @@
 		primarily programming techniques and cache configuration. </shortdesc>
 	<conbody>
 		<p>Before you begin, you should understand <keyword keyref="product_name_long"/> <xref
-				href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+				href="../../basic_config/book_intro.xml" type="concept"
 				format="dita" scope="local"
 				><?xm-replace_text Basic Configuration and Programming?></xref>. </p>
 	</conbody>

--- a/managing/monitor_tune/performance_controls_increasing_cache_hits.xml
+++ b/managing/monitor_tune/performance_controls_increasing_cache_hits.xml
@@ -9,7 +9,7 @@
 			entry expiration or eviction enabled, monitor the region and entry statistics. </p>
 		<p>If you see a high ratio of misses to hits on the entries, consider increasing the
 			expiration times or the maximum values for eviction, if possible. See <xref
-				href="../../developing/eviction/chapter_overview.xml#eviction" format="dita"
+				href="../../developing/eviction/chapter_overview.xml" format="dita"
 				><?xm-replace_text Eviction?></xref> for more information. </p>
 	</conbody>
 </concept>

--- a/managing/monitor_tune/performance_controls_managing_slow_receivers.xml
+++ b/managing/monitor_tune/performance_controls_managing_slow_receivers.xml
@@ -10,7 +10,7 @@
 	<conbody id="conbody_l4j_lpb_rr">
 		<p>Most of the options for handling slow members are related to on-site configuration during
 			system integration and tuning. For this information, see <xref
-				href="slow_receivers.xml#slow_recv" type="concept" format="dita" scope="local"
+				href="slow_receivers.xml" type="concept" format="dita" scope="local"
 				><?xm-replace_text Slow Receivers with TCP/IP?></xref>. </p>
 		<p>Slowing is more likely to occur when applications run many threads, send large messages
 			(due to large entry values), or have a mix of region configurations. </p>

--- a/managing/monitor_tune/slow_receivers.xml
+++ b/managing/monitor_tune/slow_receivers.xml
@@ -8,7 +8,7 @@
 		using the UDP unicast or multicast protocols.</shortdesc>
 	<conbody id="conbody_ozh_bqb_rr">
 		<p> Before you begin, you should understand <keyword keyref="product_name"/>
-			<xref href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+			<xref href="../../basic_config/book_intro.xml" type="concept"
 				format="dita" scope="local"
 				><?xm-replace_text Basic Configuration and Programming?></xref>. </p>
 	</conbody>

--- a/managing/monitor_tune/slow_receivers_managing.xml
+++ b/managing/monitor_tune/slow_receivers_managing.xml
@@ -36,7 +36,7 @@
 			producer and that consumer, regardless of scope. </p>
 		<p>
 			<note>These slow receiver options are disabled in systems using SSL. See <xref
-					href="../security/ssl_overview.xml#ssl" type="concept" format="dita"
+					href="../security/ssl_overview.xml" type="concept" format="dita"
 					scope="local"><?xm-replace_text SSL?></xref>. </note>
 		</p>
 		<p>Each consumer member determines how its own slow behavior is to be handled by its

--- a/managing/monitor_tune/socket_communication.xml
+++ b/managing/monitor_tune/socket_communication.xml
@@ -12,7 +12,7 @@
 		<p>All of the settings discussed here are listed as <codeph>gemfire.properties</codeph> and
 				<codeph>cache.xml</codeph> settings. They can also be configured through the API and
 			some can be configured at the command line. Before you begin, you should understand
-			<keyword keyref="product_name"/> <xref href="../../basic_config/book_intro.xml#basic_config_management"
+			<keyword keyref="product_name"/> <xref href="../../basic_config/book_intro.xml"
 				type="concept" format="dita" scope="local"/>. </p>
 	</conbody>
 </concept>

--- a/managing/monitor_tune/system_member_performance.xml
+++ b/managing/monitor_tune/system_member_performance.xml
@@ -5,7 +5,7 @@
   <shortdesc>You can modify some configuration parameters to improve system member performance. </shortdesc>
   <conbody>
     <p> Before doing so, you should understand <xref
-        href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+        href="../../basic_config/book_intro.xml" type="concept"
         format="dita" scope="local"><?xm-replace_text Basic Configuration and Programming?></xref>.
     </p>
   </conbody>

--- a/managing/monitor_tune/udp_communication.xml
+++ b/managing/monitor_tune/udp_communication.xml
@@ -12,11 +12,11 @@
 				keyref="product_name"/> also provides statistics to help you decide when to change
 			your UDP messaging settings. </p>
 		<p>Before you begin, you should understand <keyword keyref="product_name"/>
-			<xref href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+			<xref href="../../basic_config/book_intro.xml" type="concept"
 				format="dita" scope="local"
 				><?xm-replace_text Basic Configuration and Programming?></xref>. See also the
 			general communication tuning and multicast-specific tuning covered in <xref
-				href="socket_communication.xml#socket_comm" type="concept" format="dita"
+				href="socket_communication.xml" type="concept" format="dita"
 				scope="local"><?xm-replace_text Socket Communication?></xref> and <xref
 				href="multicast_communication.xml#multicast" type="concept" format="dita"
 				scope="local"><?xm-replace_text Multicast Communication?></xref>. </p>

--- a/managing/network_partitioning/handling_network_partitioning.xml
+++ b/managing/network_partitioning/handling_network_partitioning.xml
@@ -11,7 +11,7 @@
 					<li id="li_0CBFE55931764F89A7DD9EB50F2EED54">Network partition detection can
 						work in multicast or in locator-based environments. If you are using
 						locators for member discovery, use multiple locators. See <xref
-							href="../../topologies_and_comm/p2p_configuration/setting_up_a_p2p_system.xml#setting_up_membership"
+							href="../../topologies_and_comm/p2p_configuration/setting_up_a_p2p_system.xml"
 							type="concept" format="dita" scope="local"/>. </li>
 					<li id="li_1D5D74CEB2C140149357D9300FD41E33">Enable partition detection
 						consistently in all system members by setting this in their
@@ -83,7 +83,7 @@ This can lead to cache inconsistencies if there is a network failure.</codeblock
 								a network partition event will automatically restart and attempt to
 								reconnect. Data members will attempt to reinitialize the cache. See
 									<xref
-									href="../autoreconnect/member-reconnect.xml#concept_22EE6DDE677F4E8CAF5786E17B4183A9"
+									href="../autoreconnect/member-reconnect.xml"
 								/>. You can modify the number of times that a member will try to
 								reconnect by specifying the <codeph>max-num-reconnect-tries</codeph>
 								property.</li>

--- a/managing/network_partitioning/how_network_partitioning_management_works.xml
+++ b/managing/network_partitioning/how_network_partitioning_management_works.xml
@@ -50,7 +50,7 @@
 								the system, it is possible that members are also being removed
 								through the normal failure detection process. Failure detection
 								removes unresponsive or slow members. See <xref
-									href="../monitor_tune/slow_receivers_managing.xml#slow_recv"
+									href="../monitor_tune/slow_receivers_managing.xml"
 									type="concept" format="dita" scope="local"/> and <xref
 									href="failure_detection.xml#concept_CFD13177F78C456095622151D6EE10EB"
 									type="concept" format="dita" scope="local"/> for descriptions of

--- a/managing/security/implementing_security.xml
+++ b/managing/security/implementing_security.xml
@@ -12,7 +12,7 @@
 					<li id="li_A9B61790816F4E9C988457D65C6C75B1">Use locators for peer discovery
 						within the distributed systems and for client discovery of servers. See
 							<xref scope="local"
-							href="../../topologies_and_comm/p2p_configuration/setting_up_a_p2p_system.xml#setting_up_membership"
+							href="../../topologies_and_comm/p2p_configuration/setting_up_a_p2p_system.xml"
 							type="concept" format="dita"/>
 							 and <xref
 							href="../../topologies_and_comm/cs_configuration/setting_up_a_client_server_system.xml#setting_up_a_client_server_system"

--- a/managing/security/implementing_ssl.xml
+++ b/managing/security/implementing_ssl.xml
@@ -210,7 +210,7 @@
 							<li id="li_A6D919D68A9A405793554C373FC3EB61">Use locators for member
 								discovery within the distributed systems and for client discovery of
 								servers. See <xref scope="local"
-									href="../../topologies_and_comm/p2p_configuration/setting_up_a_p2p_system.xml#setting_up_membership"
+									href="../../topologies_and_comm/p2p_configuration/setting_up_a_p2p_system.xml"
 									type="concept" format="dita"
 									><?xm-replace_text Configuring Peer-to-Peer Discovery?></xref>
 								and <xref

--- a/managing/security/management_system_jmx_authentication.xml
+++ b/managing/security/management_system_jmx_authentication.xml
@@ -49,7 +49,7 @@ gemfiremanager readwrite</codeblock>
 					can override the SSL configuration for JMX clients by configuring JMX manager
 					configuration properties (such as <codeph>jmx-manager-ssl</codeph>) in the
 						<codeph>gfsecurity.properties</codeph> file. See <xref
-						href="implementing_ssl.xml#implementing_ssl" type="concept" format="dita"
+						href="implementing_ssl.xml" type="concept" format="dita"
 						scope="local"/>. </li>
 			</ol>
 		</p>

--- a/managing/security/security_audit_overview.xml
+++ b/managing/security/security_audit_overview.xml
@@ -1,22 +1,19 @@
 <?xml version="1.0"?>
 <!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<dita> 
-  <topic id="topic_36C918B4202D45F3AC225FFD23B11D7C"> 
-	 <title>Security Information Specific to Pivotal GemFire</title> 
-	 <shortdesc>Pivotal is committed to providing products and solutions that
-		allow you to assess the security of your information, secure your information
-		infrastructure, protect your sensitive information, and manage security
-		information and events to assure effectiveness and regulatory compliance. 
-	 </shortdesc> 
-	 <body>
-		<p>As part of this commitment, the following Pivotal GemFire-specific
-		  security information is provided to help you secure your environment.
-		</p> 
-		<p>Note that the intent of this section is to gather discrete pieces of
-		  information in one convenient location to better help you assess and configure
-		  the security of your environment. For additional details about the information,
-		  see the appropriate sections in this User Guide. 
-		</p> 
-	 </body> 
-  </topic> 
-</dita> 
+<dita>
+	<topic id="topic_36C918B4202D45F3AC225FFD23B11D7C">
+		<title>Security Information Specific to Pivotal GemFire</title>
+		<shortdesc>Pivotal is committed to providing products and solutions that allow you to assess
+			the security of your information, secure your information infrastructure, protect your
+			sensitive information, and manage security information and events to assure
+			effectiveness and regulatory compliance. </shortdesc>
+		<body>
+			<p>As part of this commitment, the following Pivotal GemFire-specific security
+				information is provided to help you secure your environment. </p>
+			<p>Note that the intent of this section is to gather discrete pieces of information in
+				one convenient location to better help you assess and configure the security of your
+				environment. For additional details about the information, see the appropriate
+				sections in this User Guide. </p>
+		</body>
+	</topic>
+</dita>

--- a/managing/security/ssl_example.xml
+++ b/managing/security/ssl_example.xml
@@ -48,7 +48,7 @@ security-userPassword=yyyy
 			</p>
 			<p>Note that individual provider settings can also be overriden for client/server, JMX,
 				or HTTP connections by setting the appropriate property here. See <xref
-					href="implementing_ssl.xml#implementing_ssl"/>.</p>
+					href="implementing_ssl.xml"/>.</p>
 		</section>
 		<section id="section_32E55F2088804667BB448DB577AC2940">
 			<title>Locator Startup</title>

--- a/managing/statistics/setting_up_statistics.xml
+++ b/managing/statistics/setting_up_statistics.xml
@@ -20,7 +20,7 @@
 		<section id="section_215BB4074BD64834BAADA87BE84C34DE">
 			<title>Configure Statistics</title>
 			<p>In this procedure it is assumed that you understand <xref
-					href="../../basic_config/book_intro.xml#basic_config_management" type="concept"
+					href="../../basic_config/book_intro.xml" type="concept"
 					format="dita" scope="local"/>. </p>
 			<ol id="ol_BA9F16EB6E5A4D2D8CB65E26B9DDA306">
 				<li>In gfsh, start your locator running the cluster configuration service

--- a/managing/troubleshooting/diagnosing_system_probs.xml
+++ b/managing/troubleshooting/diagnosing_system_probs.xml
@@ -291,7 +291,7 @@ at . . . </codeblock>
 					<li id="li_674154D94A5B4C4AAF21325F953D859D"><b>During initialization</b>—For
 						persistent regions, the member may be waiting for another member with more
 						recent data to start and load from its disk stores. See <xref
-							href="../disk_storage/chapter_overview.xml#disk_storage" format="dita"
+							href="../disk_storage/chapter_overview.xml" format="dita"
 							>Disk Storage</xref>. Wait for the initialization to finish or time out.
 						The process could be busy—some caches have millions of entries, and they can
 						take a long time to load. Look for this especially with cache servers,
@@ -438,7 +438,7 @@ Document root element "cache", must match DOCTYPE root "client-cache".</codebloc
 			<p>Response: Use a partitioned or replicate data-policy for your server regions. This is
 				the only way to provide a consistent view to clients of your server data set. See
 					<xref
-					href="../../developing/region_options/chapter_overview.xml#determining_storage_and_dist"
+					href="../../developing/region_options/chapter_overview.xml"
 					format="dita">Region Data Storage and Distribution Options</xref>. </p>
 		</section>
 		<section id="section_9276E09D9FAC408E899F73B7068E80C6">
@@ -479,9 +479,9 @@ created at timestamp 1270834766733 version 0]</codeblock>
 					<li id="li_940BFF0CB1004D13935D5A48A42A0B14">Partitioned regions—For performance
 						reasons, eviction and expiration behave differently in partitioned regions
 						and can cause entries to be removed before you expect. See <xref
-							href="../../developing/eviction/chapter_overview.xml#eviction"
+							href="../../developing/eviction/chapter_overview.xml"
 							format="dita"><?xm-replace_text Eviction?></xref> and <xref
-							href="../../developing/expiration/chapter_overview.xml#expiration"
+							href="../../developing/expiration/chapter_overview.xml"
 							format="dita"><?xm-replace_text Expiration?></xref>. </li>
 				</ul>
 			</p>
@@ -569,7 +569,7 @@ created at timestamp 1270834766733 version 0]</codeblock>
 						<row>
 							<entry>
 								<xref
-									href="../../developing/management_all_region_types/chapter_overview.xml#storing_data_on_disk"
+									href="../../developing/management_all_region_types/chapter_overview.xml"
 									type="concept" format="dita" scope="local"
 									><?xm-replace_text General Region Data Management?></xref>
 							</entry>
@@ -673,7 +673,7 @@ created at timestamp 1270834766733 version 0]</codeblock>
 						<row>
 							<entry>
 								<xref
-									href="../../developing/management_all_region_types/chapter_overview.xml#storing_data_on_disk"
+									href="../../developing/management_all_region_types/chapter_overview.xml"
 									type="concept" format="dita" scope="local"
 									><?xm-replace_text General Region Data Management?></xref>
 							</entry>
@@ -880,7 +880,7 @@ within member-timeout milliseconds</codeblock>
 			<p>Response: </p>
 			<p>If you are experiencing slow performance and are sending large objects (multiple
 				megabytes), try increasing the socket buffer size settings in your system. For more
-				information, see <xref href="../monitor_tune/socket_communication.xml#socket_comm"
+				information, see <xref href="../monitor_tune/socket_communication.xml"
 					type="concept" format="dita" scope="local"
 					><?xm-replace_text Socket Communication?></xref>. </p>
 		</section>

--- a/managing/troubleshooting/prevent_and_recover_disk_full_errors.xml
+++ b/managing/troubleshooting/prevent_and_recover_disk_full_errors.xml
@@ -39,7 +39,7 @@
             href="../../tools_modules/gfsh/command-pages/show.xml#topic_7B3D624D5B4F41D1A0F8A9C3C8B2E780"
           /> command to identify any missing data. You may need to manually restore this data.</li>
         <li>Revoke the missing disk stores using the <xref
-            href="../../tools_modules/gfsh/command-pages/revoke.xml#concept_22551CABF07B4512B5159DDAE036722D"
+            href="../../tools_modules/gfsh/command-pages/revoke.xml"
           /> gfsh command. </li>
         <li>Restart the member.</li>
       </ol>

--- a/managing/troubleshooting/recovering_from_cs_crashes.xml
+++ b/managing/troubleshooting/recovering_from_cs_crashes.xml
@@ -46,7 +46,7 @@
 						It might take awhile for the clients to start using the recovered server.
 						The time depends in part on how the clients are configured and how they are
 						programmed. See <xref
-							href="../../topologies_and_comm/cs_configuration/chapter_overview.xml#concept_D7677C9484874E4AAB8D810E6ADC9EE2"
+							href="../../topologies_and_comm/cs_configuration/chapter_overview.xml"
 							type="concept" format="dita" scope="local"
 							><?xm-replace_text Client/Server Configuration?></xref>. </li>
 				</ol>

--- a/managing/troubleshooting/recovering_from_network_outages.xml
+++ b/managing/troubleshooting/recovering_from_network_outages.xml
@@ -57,7 +57,7 @@
 			<p>In addition, members that have been disconnected either via network partition or due
 				to unresponsiveness will automatically try to reconnect to the distributed system
 				unless configured otherwise. See <xref
-					href="../autoreconnect/member-reconnect.xml#concept_22EE6DDE677F4E8CAF5786E17B4183A9"
+					href="../autoreconnect/member-reconnect.xml"
 				/>.</p>
 		</section>
 		<section id="section_F9A0C31AE25C4E7185DF3B1A8486BDFA">

--- a/managing/troubleshooting/recovering_from_p2p_crashes.xml
+++ b/managing/troubleshooting/recovering_from_p2p_crashes.xml
@@ -58,7 +58,7 @@
 				until a new member is brought online to replace the member that crashed. You can
 				control this behavior using the recovery delay attributes. For more information, see
 					<xref scope="local"
-					href="../../developing/partitioned_regions/configuring_ha_for_pr.xml#configuring_pr_redundancy"
+					href="../../developing/partitioned_regions/configuring_ha_for_pr.xml"
 					format="dita"/>. </p>
 			<p>To recover, start a replacement member. The new member regenerates the lost copies
 				and returns them to the configured redundancy level. </p>
@@ -96,7 +96,7 @@
 				automatically begins to create new data. </p>
 			<p>If the members with the relevant disk stores cannot be restarted, then you will have
 				to revoke the missing disk stores manually using gfsh. See <xref
-					href="../../tools_modules/gfsh/command-pages/revoke.xml#concept_22551CABF07B4512B5159DDAE036722D"
+					href="../../tools_modules/gfsh/command-pages/revoke.xml"
 				/>.</p>
 			<p>
 				<b>Maintaining and Recovering Partitioned Region Redundancy</b>
@@ -180,7 +180,7 @@ host a bucket in the partitioned region.</codeblock>
 			<title>Recovering Data from Disk</title>
 			<p>When you persist a region, the entry data on disk outlives the region in memory. If
 				the member exits or crashes, the data remains in the region’s disk directories. See
-					<xref href="../disk_storage/chapter_overview.xml#disk_storage" type="concept"
+					<xref href="../disk_storage/chapter_overview.xml" type="concept"
 					format="dita" scope="local"/>. If the same region is created again, this saved
 				disk data can be used to initialize the region. </p>
 			<p>Some general considerations for disk data recovery: </p>
@@ -193,7 +193,7 @@ host a bucket in the partitioned region.</codeblock>
 				<li>When a region is initialized from disk, last modified time is persisted from
 					before the member exit or crash. For information on how this might affect the
 					region data, see <xref
-						href="../../developing/expiration/chapter_overview.xml#expiration"
+						href="../../developing/expiration/chapter_overview.xml"
 						type="concept" format="dita" scope="local"
 						><?xm-replace_text Expiration?></xref>.</li>
 			</ul>

--- a/reference/topics/agent_properties.xml
+++ b/reference/topics/agent_properties.xml
@@ -15,7 +15,7 @@
 	 <p>By default, the Agent properties file is named 
 		<codeph>agent.properties</codeph>. You can specify a different properties
 		file on the command line when you launch the JMX Agent. See 
-		<xref href="../../managing/jmx/starting_jmx_agent.xml#how_logging_works"
+		<xref href="../../managing/jmx/starting_jmx_agent.xml"
 		 type="concept" format="dita" scope="local"><?xm-replace_text Starting the vFabric       JMX Agent?></xref>.
 		Availble Agent properties include: 
 	 <ul id="ul_A3F4B0C478914DA9A99DE364B41064E9"> 

--- a/reference/topics/cache_xml.xml
+++ b/reference/topics/cache_xml.xml
@@ -149,8 +149,7 @@
 				rollbacks. </p>
 			<p>Specify the Java class and its initialization parameters with the
 					<codeph>&lt;class-name&gt;</codeph> and <codeph>&lt;parameter&gt;</codeph>
-				sub-elements. See <xref format="dita" href="cache_xml.xml#class-name_parameter"
-					scope="local" type="topic"><?xm-replace_text and ?></xref>. </p>
+				sub-elements. See <xref href="#class-name_parameter" format="dita"/>. </p>
 		</body>
 	</topic>
 	<topic id="transaction-writer">
@@ -175,9 +174,7 @@
 				Java code to dynamically create regions. <note>You can not use this element to
 					dynamically create <i>partitioned</i> regions. </note></p>
 			<p>Pivotal Inc. recommends that you use functions to dynamically create regions. See
-					<xref
-					href="../../developing/region_options/dynamic_region_creation.xml#concept_tr5_rdp_wk"
-				/>.</p>
+					<xref href="../../developing/region_options/dynamic_region_creation.xml"/>.</p>
 			<p> The optional <codeph>&lt;disk-dir></codeph> sub-element specifies the directory to
 				store the persistent files that are used for dynamic region bookkeeping. It defaults
 				to the current directory. </p>
@@ -558,7 +555,7 @@
 		<body>
 			<p>Deprecated as of GemFire 7.0. Specify server groups in the gemfire.properties file.
 				See <xref
-					href="../../topologies_and_comm/cs_configuration/configure_servers_into_logical_groups.xml#configure_servers_into_logical_groups"
+					href="../../topologies_and_comm/cs_configuration/configure_servers_into_logical_groups.xml"
 					>Organizing Servers Into Logical Member Groups</xref>. </p>
 		</body>
 	</topic>
@@ -625,7 +622,7 @@
 			<codeblock outputclass="language-xml">&lt;cache-server port=4444&gt;
 &lt;/cache&gt;</codeblock>
 		</body>
-	</topic>	
+	</topic>
 	<topic id="custom-load-probe">
 		<title>&lt;custom-load-probe&gt;</title>
 		<shortdesc> </shortdesc>
@@ -2127,8 +2124,7 @@
 			<p>Specifies the custom class that implements
 					<codeph>com.gemstone.gemfire.cache.CustomExpiry</codeph>. You define this class
 				in order to override the region-wide settings for specific entries. See <xref
-					format="dita"
-					href="../../developing/expiration/configuring_data_expiration.xml#configuring_data_expiration"
+					format="dita" href="../../developing/expiration/configuring_data_expiration.xml"
 					scope="local" type="concept"/> for an example. </p>
 			<p>Specify the Java class and its initialization parameters with the
 					<codeph>&lt;class-name&gt;</codeph> and <codeph>&lt;parameter&gt;</codeph>
@@ -3394,7 +3390,7 @@
 							<entry colname="1">name </entry>
 							<entry colname="2">Specify the name for the region. See <xref
 									format="dita"
-									href="../../basic_config/data_regions/create_a_region_with_cacheXML.xml#create_a_region_with_cacheXML"
+									href="../../basic_config/data_regions/create_a_region_with_cacheXML.xml"
 									scope="local" type="task"/> for details. </entry>
 							<entry colname="col3"/>
 						</row>
@@ -3405,9 +3401,9 @@
 								it will cause the "refid" on the region to be ignored. The "refid"
 								region attriibute can be set to the name of a RegionShortcut or a
 								ClientRegionShortcut. For more information, see <xref format="dita"
-									href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts"
+									href="../../basic_config/data_regions/region_shortcuts.xml"
 									scope="local" type="concept"/> and <xref format="dita"
-									href="../../basic_config/data_regions/store_retrieve_region_shortcuts.xml#region_shortcuts"
+									href="../../basic_config/data_regions/store_retrieve_region_shortcuts.xml"
 									scope="local" type="concept"/>. </entry>
 							<entry colname="col3"/>
 						</row>
@@ -3447,10 +3443,10 @@
 			<p>Describes an index to be created on a region. The index node, if any, should all come
 				immediately after the "region-attributes" node. The "name" attribute is a required
 				field which identifies the name of the index. See <xref format="dita"
-					href="../../developing/query_index/query_index.xml#indexing" scope="local"
-					type="concept"/> for more information on indexes. You can create either a
-				functional index with the <codeph>&lt;functional&gt;</codeph> sub-element or a
-				primary-key index with the <codeph>&lt;primary-key&gt;</codeph> element. </p>
+					href="../../developing/query_index/query_index.xml" scope="local" type="concept"
+				/> for more information on indexes. You can create either a functional index with
+				the <codeph>&lt;functional&gt;</codeph> sub-element or a primary-key index with the
+					<codeph>&lt;primary-key&gt;</codeph> element. </p>
 			<p>
 				<b>Default: </b>
 			</p>

--- a/reference/topics/chapter_overview_cache_xml.xml
+++ b/reference/topics/chapter_overview_cache_xml.xml
@@ -9,9 +9,9 @@
 	<body>
 		<note>You can configure most elements of the cache.xml file and apply it to your entire
 			cluster by using the <xref
-				href="../../tools_modules/gfsh/chapter_overview.xml#concept_36339CCA6323430D8B61EE8DC5F64DCB"
+				href="../../tools_modules/gfsh/chapter_overview.xml"
 				>gfsh</xref> and <xref
-				href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl">cluster
+				href="../../configuring/cluster_config/gfsh_persist.xml">cluster
 				configuration service</xref>. See <xref
 				href="../../configuring/cluster_config/gfsh_persist.xml#concept_r22_hyw_bl/section_bn3_23p_y4"
 			/> for a list of items you cannot configure in gfsh and must still configure in

--- a/reference/topics/chapter_overview_regionshortcuts.xml
+++ b/reference/topics/chapter_overview_regionshortcuts.xml
@@ -26,7 +26,7 @@
 &lt;/region&gt;</codeblock>
       </p>
       <p>You can also create your own, named region shortcuts for common custom configurations. See
-          <xref href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts"/>. </p>
+          <xref href="../../basic_config/data_regions/region_shortcuts.xml"/>. </p>
       <p>To configure a region using the gfsh command-line tool, specify the shortcut name with the
           <cmdname>--type</cmdname> argument. For example:
         <codeblock>gfsh&gt;create region --name=myRegion --type=PARTITION_REDUNDANT</codeblock>

--- a/reference/topics/gemfire_properties.xml
+++ b/reference/topics/gemfire_properties.xml
@@ -20,7 +20,7 @@
 			or in your environment.</p>
 		<p id="p_lgg_ccp_rr">You can specify non-ASCII text in your properties files by using
 			Unicode escape sequences. See <xref
-				href="non-ascii_strings_in_config_files.xml#concept_D3BC1489F5D8494799E8D2A8FE7EE81D"
+				href="non-ascii_strings_in_config_files.xml"
 				type="concept" format="dita" scope="local"/> for more details. </p>
 		<note>Unless otherwise indicated, these settings only affect activities within this
 			distributed system - not activities between clients and servers. </note>
@@ -172,7 +172,7 @@
 							property (<codeph>server-ssl-enabled</codeph>,
 								<codeph>jmx-manager-ssl-enabled</codeph>, or
 								<codeph>http-service-ssl-enabled</codeph>) is defined. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry id="entry_vmz_4dp_rr">false</entry>
 					</row>
@@ -188,7 +188,7 @@
 							connections. Specify the jmx-manager, server- or http-service- prefix
 							with this property to use a different keystore for the respective SSL
 							connection type. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 								/>.<note>javax.net.ssl.keyStore is deprecated. Use
 									<codeph>cluster-ssl-keystore</codeph> instead.</note></entry>
 						<entry colname="3" id="entry_jbp_pdp_rr">
@@ -201,7 +201,7 @@
 							server-ssl-keystore-password</entry>
 						<entry id="entry_sq4_tdp_rr">Properties that identify the passwords for the
 							keystores used with SSL connections. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 								/>.<note>javax.net.ssl.keyStorePassword is deprecated. Use
 								cluster-ssl-keystore-password instead.</note></entry>
 						<entry colname="3" id="entry_k4s_tdp_rr">
@@ -214,7 +214,7 @@
 							server-ssl-keystore-type</entry>
 						<entry id="entry_n5d_5dp_rr">System properties that identify the types of
 							keystores used with SSL connections. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 								/>.<note>javax.net.ssl.keyStoreType is deprecated. Use
 								cluster-ssl-keystore-type instead.</note></entry>
 						<entry colname="3" id="entry_df3_5dp_rr">
@@ -232,7 +232,7 @@
 								(<codeph>server-ssl-protocols</codeph>,
 								<codeph>jmx-manager-ssl-protocols</codeph>, or
 								<codeph>http-service-ssl-protocols</codeph>) is defined. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry id="entry_cb5_22p_rr">any </entry>
 					</row>
@@ -247,7 +247,7 @@
 								<codeph>jmx-manager-ssl-require-authentication</codeph>, or
 								<codeph>http-service-ssl-require-authentication</codeph>) is
 							defined. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry id="entry_lff_f2p_rr">true </entry>
 					</row>
@@ -264,7 +264,7 @@
 							Specify the jmx-manager, server-, or http-service- prefix with this
 							property to use a different truststore for the respective SSL connection
 							type. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 								/>.<note>javax.net.ssl.trustStore is deprecated. Use
 									<codeph>cluster-ssl-truststore</codeph> instead.</note></entry>
 						<entry colname="3" id="entry_ikw_f2p_rr">
@@ -278,7 +278,7 @@
 							server-ssl-truststore-password</entry>
 						<entry id="entry_u32_g2p_rr">Properties that identifies the passwords for
 							the truststores used with SSL connections. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_vqh_g2p_rr">
 							<i>not set</i>
@@ -329,7 +329,7 @@
 							system by a network partition event or has otherwise been shunned by
 							other members. Use this property to turn off the autoreconnect behavior.
 							See <xref
-								href="../../managing/autoreconnect/member-reconnect.xml#concept_22EE6DDE677F4E8CAF5786E17B4183A9"
+								href="../../managing/autoreconnect/member-reconnect.xml"
 							/> for more details.</entry>
 						<entry id="entry_syc_j2p_rr">false </entry>
 					</row>
@@ -409,7 +409,7 @@
 							this member belongs to. Use commas to separate group names. Note that
 							anything defined by the roles gemfire property will also be considered a
 							group. See <xref
-								href="../../configuring/cluster_config/using_member_groups.xml#concept_5B60087DA11644C49250064BAB8AFFA6"
+								href="../../configuring/cluster_config/using_member_groups.xml"
 								type="concept" format="dita" scope="local"/> for more information. </entry>
 						<entry colname="3" id="entry_gjq_52p_rr">
 							<i>not set</i>
@@ -562,7 +562,7 @@
 								<keyword keyref="product_name"/> uses the value of
 								<codeph>cluster-ssl-enabled</codeph> to determine whether JMX
 							connections should use SSL. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_ift_hfp_rr">value of
 								<codeph>cluster-ssl-enabled</codeph></entry>
@@ -575,7 +575,7 @@
 							this property is not set, then <keyword keyref="product_name"/> uses the
 							value of <codeph>cluster-ssl-ciphers</codeph> to determine which SSL
 							ciphers are used for JMX connections. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_qzd_3fp_rr">value of
 								<codeph>cluster-ssl-ciphers</codeph></entry>
@@ -588,7 +588,7 @@
 							this property is not set, then <keyword keyref="product_name"/> uses the
 							value of <codeph>cluster-ssl-protocols</codeph> to determine which SSL
 							protocols are used for JMX connections. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_bxt_3fp_rr">value of
 								<codeph>cluster-ssl-ciphers</codeph></entry>
@@ -601,7 +601,7 @@
 							not set, then <keyword keyref="product_name"/> uses the value of
 								<codeph>cluster-ssl-require-authentication</codeph> to determine
 							whether JMX connections require authentication. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_bfk_jfp_rr">value of
 								<codeph>cluster-ssl-require-authentication</codeph></entry>
@@ -892,7 +892,7 @@
 							region redundancy. If this property is set, <keyword
 								keyref="product_name"/> will not put redundant copies of data in
 							members with the same redundancy zone setting. See <xref
-								href="../../developing/partitioned_regions/configuring_ha_for_pr.xml#configuring_pr_redundancy"
+								href="../../developing/partitioned_regions/configuring_ha_for_pr.xml"
 							/> for more details.</entry>
 						<entry id="entry_u3r_cgp_rr">
 							<i>not set</i>
@@ -1062,7 +1062,7 @@
 							is not set, then <keyword keyref="product_name"/> uses the value of
 								<codeph>cluster-ssl-ciphers</codeph> to determine which ciphers are
 							used for client connections. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_m2t_tgp_rr">value of
 								<codeph>cluster-ssl-ciphers</codeph></entry>
@@ -1074,7 +1074,7 @@
 								keyref="product_name"/> uses the value of
 								<codeph>cluster-ssl-enabled</codeph> to determine whether client
 							connections use SSL. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_q2j_5gp_rr">value of
 								<codeph>cluster-ssl-enabled</codeph></entry>
@@ -1087,7 +1087,7 @@
 							this property is not set, then <keyword keyref="product_name"/> uses the
 							value of <codeph>cluster-ssl-protocols</codeph> to determine which SSL
 							protocols are used for client connections. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_akz_5gp_rr">value of
 								<codeph>cluster-ssl-protocols</codeph></entry>
@@ -1099,7 +1099,7 @@
 							set, then <keyword keyref="product_name"/> uses the value of
 								<codeph>cluster-ssl-require-authentication</codeph> to determine
 							whether client connections require authentication. See <xref
-								href="../../managing/security/implementing_ssl.xml#implementing_ssl"
+								href="../../managing/security/implementing_ssl.xml"
 							/>.</entry>
 						<entry colname="3" id="entry_yvz_vgp_rr">value of
 								<codeph>cluster-ssl-require-authentication</codeph></entry>

--- a/reference/topics/region_shortcuts_reference.xml
+++ b/reference/topics/region_shortcuts_reference.xml
@@ -73,7 +73,7 @@ Region | data-policy | NORMAL
 					memory. </p>
 				<p>For more information, see: <ul id="ul_et2_5md_4k">
 						<li id="li_D6DE1BBFC7814EA3AB3AC6A99EE21E9F"><xref
-								href="../../developing/eviction/chapter_overview.xml#eviction"/>
+								href="../../developing/eviction/chapter_overview.xml"/>
 						</li>
 						<li id="li_F18F7F2F006E49E782CEC474D95A4862"><xref
 								href="../../developing/region_options/region_types.xml#region_types/section_A8150BDBC74E4019B1942481877A4370"
@@ -140,7 +140,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 					values of entries to disk when it detects that the JVM is running low on memory. </p>
 				<p>For more information, see: <ul id="ul_mx2_435_mk">
 						<li id="li_0A2E85BC5DF942D4AC7B7DF42B5C66C2"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_810811349E614F449428C3F1AA810759"><xref
@@ -148,7 +148,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 								>Local Regions</xref>
 						</li>
 						<li id="li_91F45A7664A44887B73EB2A4347D52A2"><xref
-								href="../../developing/eviction/chapter_overview.xml#eviction"/>
+								href="../../developing/eviction/chapter_overview.xml"/>
 						</li>
 					</ul>
 				</p>
@@ -210,7 +210,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 					writes its state to disk and can recover that state when the member restarts. </p>
 				<p>For more information, see: <ul id="ul_pwg_x35_mk">
 						<li id="li_D9BCDB9A8E8C4823AAC67AA658E4B9DF"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_D0ACD73B28374706A37D576A77210F4D"><xref
@@ -273,7 +273,7 @@ Region | size | 0</codeblock>
 					the JVM is running low on memory. </p>
 				<p>For more information, see: <ul id="ul_vll_gj5_mk">
 						<li id="li_2F9F24A2E9D244B195C1049AB4384A02"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_A9D37C283A55456F9E021BF383311285"><xref
@@ -345,7 +345,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 								>Local Regions</xref>
 						</li>
 						<li id="li_DF431454269D48B79F1DFF61142C0C8A"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_9601CB87C8604DF7B06E9A4DFDF5FF05"><xref
@@ -404,7 +404,7 @@ Region | size | 0</codeblock>
 					destroys entries when it detects that the JVM is running low on memory. </p>
 				<p>For more information, see: <ul id="ul_lcp_5k5_mk">
 						<li id="li_E7CCD0A6C60F40EEBB68A78489B748CA"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_02FFBB6240CB4677B3F10424B586AEB3"><xref
@@ -412,10 +412,10 @@ Region | size | 0</codeblock>
 								>Local Regions</xref>
 						</li>
 						<li id="li_9FC2C6A659D94CCC84256088A6BC70D5"><xref
-								href="../../developing/eviction/chapter_overview.xml#eviction"/>
+								href="../../developing/eviction/chapter_overview.xml"/>
 						</li>
 						<li id="li_DF20E4DEC8A04DF5BE0666647E2D1368"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -482,7 +482,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 					detects that the JVM is running low on memory. </p>
 				<p>For more information, see: <ul id="ul_hhf_dl5_mk">
 						<li id="li_F625DDFDA4DB457B917E4BFCA4E224A4"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_D7592AF8D11E47A9ACBF0E677B3ED91F"><xref
@@ -490,11 +490,11 @@ Eviction | eviction-algorithm | lru-heap-percentage
 								>Local Regions</xref>
 						</li>
 						<li id="li_A20297613CF04B2EA556997C8772F2A9"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_86171CC7778548449668408670AEAEA8"><xref
-								href="../../developing/eviction/chapter_overview.xml#eviction"/>
+								href="../../developing/eviction/chapter_overview.xml"/>
 						</li>
 					</ul>
 				</p>
@@ -564,11 +564,11 @@ Eviction | eviction-algorithm | lru-heap-percentage
 							</p>
 						</li>
 						<li id="li_1E80D6AFA86F4E18B780CA85F6F3E98C"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_F84379836535451B8D1AA558464C410B"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -624,30 +624,29 @@ Region | size | 0</codeblock>
 					member restarts. . The region removes the values of entries from memory when it
 					detects that the JVM is running low on memory. </p>
 				<p>For more information, see: <ul id="ul_r4p_5t5_mk">
-						<li id="li_AD33F0B48FEB4C819CF3479C73354F98"><xref
+						<li id="li_AD33F0B48FEB4C819CF3479C73354F98">
+							<xref
 								href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts/section_D0975C76572E41F79C1A6EE7CF371251"
-								>RegionShortcuts for Peers and Servers</xref>
-						</li>
+							/></li>
 						<li id="li_6AB56F40B97D44A19B06104DDFA1846D"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_EB35B61D082E4AEF8F2ECF8F796D21A6"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
 				</p>
 			</section>
-			<section id="section_3A5BF41715ED499193A42119F9F4C8B8">
-				<title>Default Attributes</title>
-				<p>
+			<section id="section_3A5BF41715ED499193A42119F9F4C8B8"><xref
+					href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts/section_D0975C76572E41F79C1A6EE7CF371251"
+					/><title>Default Attributes</title><p>
 					<parmname>Region Attributes</parmname>
-				</p>
-				<p conref="region_shortcuts_table.xml#reference_ufj_5kz_4k/p_axq_jc1_nk"/>
-				<p conref="region_shortcuts_table.xml#reference_ufj_5kz_4k/p_gxq_jc1_nk"/>
-				<p conref="region_shortcuts_table.xml#reference_ufj_5kz_4k/p_lxq_jc1_nk"/>
-			</section>
+				</p><p conref="region_shortcuts_table.xml#reference_ufj_5kz_4k/p_axq_jc1_nk"/><p
+					conref="region_shortcuts_table.xml#reference_ufj_5kz_4k/p_gxq_jc1_nk"/><p
+					conref="region_shortcuts_table.xml#reference_ufj_5kz_4k/p_lxq_jc1_nk"
+				/></section>
 			<section id="section_64138E9923064EBC8007B6803223E64F">
 				<title>gfsh Command Example</title>
 				<codeblock>gfsh&gt;create region --name=myPPOregion --type=PARTITION_PERSISTENT_OVERFLOW
@@ -697,12 +696,12 @@ Eviction | eviction-algorithm | lru-heap-percentage
 					the <parmname>PARTITION</parmname> shortcut or a peer region configured with the
 						<parmname>PARTITION_PERSISTENT</parmname> shortcut. </p>
 				<p>See: <ul id="ul_ubc_kx5_mk">
-						<li id="li_DD147C1C4AD745E08EA3FBA6448B2D6B"><xref
+						<li><xref
 								href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts/section_D0975C76572E41F79C1A6EE7CF371251"
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_B97D4E9F0BD04A6BA7535086AAA42303"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -768,7 +767,7 @@ Partition | local-max-memory | 0</codeblock>
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_3626B2380C914D8DAC28C1F56843E27A"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -834,7 +833,7 @@ Partition | redundant-copies | 1
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_1FF1BD0C0CAF4B64A6BA3254F4BFA918"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -895,7 +894,7 @@ Partition | redundant-copies | 1</codeblock>
 					region destroys entries when it detects that the JVM is running low on memory. </p>
 				<p>For more information, see: <ul id="ul_jkm_jw5_mk">
 						<li id="li_1C1C22968CCA4B468E6AC444948F434F"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_56FF93BF5AB0450AB4A3D224F6F24D24"><xref
@@ -903,14 +902,14 @@ Partition | redundant-copies | 1</codeblock>
 								>Local Regions</xref>
 						</li>
 						<li id="li_FD612340AB2140988461A0CD6E38C9FA"><xref
-								href="../../developing/eviction/chapter_overview.xml#eviction"/>
+								href="../../developing/eviction/chapter_overview.xml"/>
 						</li>
 						<li id="li_ED3CE196E5C64E19B6F2EA6A32443D60"><xref
 								href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts/section_D0975C76572E41F79C1A6EE7CF371251"
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_4BDA730A68EA4B26960762CCCC183E59"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -982,7 +981,7 @@ Partition | redundant-copies   | 1</codeblock>
 					running low on memory. </p>
 				<p>For more information, see: <ul id="ul_llk_pw5_mk">
 						<li id="li_15FBCDF9D5D9474B9511CD68838E1C2E"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_8F2A17BC701B448B92733F844E82156E"><xref
@@ -990,14 +989,14 @@ Partition | redundant-copies   | 1</codeblock>
 								>Local Regions</xref>
 						</li>
 						<li id="li_9B76CA035A774BB09C2B25C23A23E990"><xref
-								href="../../developing/eviction/chapter_overview.xml#eviction"/>
+								href="../../developing/eviction/chapter_overview.xml"/>
 						</li>
 						<li id="li_87E69519888A489BA75CC61C45C155B7"><xref
 								href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts/section_D0975C76572E41F79C1A6EE7CF371251"
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_A06D5EA6AAE944A5B322DD6BEDBF4BC6"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -1067,14 +1066,14 @@ Partition | redundant-copies   | 1</codeblock>
 					data in memory. </p>
 				<p>For more information, see: <ul id="ul_d3d_5w5_mk">
 						<li id="li_DCF0B1E5637D41E99737FF94ACC12E22"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_79209C59940846508B1BB1DABBA564A4"><xref
 								href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts/section_D0975C76572E41F79C1A6EE7CF371251"
 								>RegionShortcuts for Peers and Servers</xref>. </li>
 						<li id="li_BE02A0D486ED40F3949C59381E695129"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -1138,14 +1137,14 @@ Partition | redundant-copies | 1</codeblock>
 					that the JVM is running out of memory. </p>
 				<p>For more information, see: <ul id="ul_e1q_px5_mk">
 						<li id="li_BF95755417764586A2FB772F278BDCF1"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_774C4B0D1B674C9790929225E015D4D1"><xref
 								href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts/section_D0975C76572E41F79C1A6EE7CF371251"
 								>RegionShortcuts for Peers and Servers</xref>. </li>
 						<li id="li_20179B1A364B40BF8FD79EADA4E3705F"><xref
-								href="../../developing/partitioned_regions/chapter_overview.xml#managing_partitioned_regions"
+								href="../../developing/partitioned_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -1208,7 +1207,7 @@ Partition | redundant-copies   | 1</codeblock>
 					REPLICATE data policy. </p>
 				<p>For more information, see: <ul id="ul_rvz_tx5_mk">
 						<li id="li_9B052217184342A79C229B9F5C3F7D2B"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_F97A026112384D6285D047620365A9F1"><xref
@@ -1216,7 +1215,7 @@ Partition | redundant-copies   | 1</codeblock>
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_6D6BB9417B624DE3B47E9130C4F5C336"><xref
-								href="../../developing/distributed_regions/chapter_overview.xml#managing_distributed_regions"
+								href="../../developing/distributed_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -1276,10 +1275,10 @@ server2 | Region "/myRregion" created on "server2"</codeblock>
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_8CB2559CA33042CFB6BBB56298C9758C"><xref
-								href="../../developing/eviction/chapter_overview.xml#eviction"/>
+								href="../../developing/eviction/chapter_overview.xml"/>
 						</li>
 						<li id="li_F289BF4F862748E2936BDD787946151E"><xref
-								href="../../developing/distributed_regions/chapter_overview.xml#managing_distributed_regions"
+								href="../../developing/distributed_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -1349,7 +1348,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 					configured with a <parmname>REPLICATE</parmname> data policy. </p>
 				<p>For more information, see: <ul id="ul_qtd_hyz_mk">
 						<li id="li_CFC3BB41C3B746DC94D6A68C1B4319D3"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_A48ED1DE95884D80996E47C4A3501AE4"><xref
@@ -1357,7 +1356,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_02A1E0E7CE2247949F30771E075B9A40"><xref
-								href="../../developing/distributed_regions/chapter_overview.xml#managing_distributed_regions"
+								href="../../developing/distributed_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -1423,7 +1422,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 					writes its state to disk and recovers that state when the member restarts. </p>
 				<p>For more information, see: <ul id="ul_ujj_5yz_mk">
 						<li id="li_FB06DCCC83F24816B178A691FDE49917"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_D65890E9BCA941BABE9C8F32FC60D08D"><xref
@@ -1431,7 +1430,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_F000178C27664A4E9B99793C46318AAB"><xref
-								href="../../developing/distributed_regions/chapter_overview.xml#managing_distributed_regions"
+								href="../../developing/distributed_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -1490,7 +1489,7 @@ Region | size | 0</codeblock>
 					running low on memory. </p>
 				<p>For more information, see: <ul id="ul_mvv_hzz_mk">
 						<li id="li_40C64F31834F4C30A79579FF7D7A1A57"><xref
-								href="../../developing/storing_data_on_disk/chapter_overview.xml#storing_data_on_disk"
+								href="../../developing/storing_data_on_disk/chapter_overview.xml"
 							/>
 						</li>
 						<li id="li_B1181E849C62465DACFD6297365382E4"><xref
@@ -1498,7 +1497,7 @@ Region | size | 0</codeblock>
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_D9448B8EAFE64FA0A91D7C41E547227D"><xref
-								href="../../developing/distributed_regions/chapter_overview.xml#managing_distributed_regions"
+								href="../../developing/distributed_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>
@@ -1572,7 +1571,7 @@ Eviction | eviction-algorithm | lru-heap-percentage
 								>RegionShortcuts for Peers and Servers</xref>
 						</li>
 						<li id="li_D6978D926747488D85710299972BFED5"><xref
-								href="../../developing/distributed_regions/chapter_overview.xml#managing_distributed_regions"
+								href="../../developing/distributed_regions/chapter_overview.xml"
 							/>
 						</li>
 					</ul>

--- a/tools_modules/gemcached/deploying_gemcached.xml
+++ b/tools_modules/gemcached/deploying_gemcached.xml
@@ -32,7 +32,7 @@
 				can alter these defaults by configuring the region using the
 					<filepath>cache.xml</filepath> or <filepath>gemfire.properties</filepath> files.
 				See <xref
-					href="../../basic_config/config_concepts/chapter_overview.xml#setting_distributed_properties"
+					href="../../basic_config/config_concepts/chapter_overview.xml"
 					type="concept"
 					format="dita"
 					scope="local"><?xm-replace_text Distributed System and Cache Configuration?></xref>.

--- a/tools_modules/gfsh/about_gfsh.xml
+++ b/tools_modules/gfsh/about_gfsh.xml
@@ -29,7 +29,7 @@
 			any commands from within an application by using a simple API. The gfsh interface uses
 			JMX/RMI to communicate with <keyword keyref="product_name_long"/> processes. </p>
 		<p>You can connect gfsh to a remote distributed system using the HTTP protocol. See <xref
-				href="../../configuring/cluster_config/gfsh_remote.xml#task_nyb_mhn_44"/>. </p>
+				href="../../configuring/cluster_config/gfsh_remote.xml"/>. </p>
 		<p>By default, the cluster configuration service saves the configuration of your <keyword
 				keyref="product_name_long"/> cluster as you create <keyword
 				keyref="product_name_long"/> objects using gfsh. You can export this configuration

--- a/tools_modules/gfsh/cache_xml_2_gfsh.xml
+++ b/tools_modules/gfsh/cache_xml_2_gfsh.xml
@@ -94,7 +94,7 @@
                                 </li>
                                 <li>
                                     <xref
-                                        href="command-pages/rebalance.xml#concept_213FDC5574474CE1AC28444DA202E05B"
+                                        href="command-pages/rebalance.xml"
                                     />
                                 </li>
                             </ul>
@@ -167,7 +167,7 @@
                                 </li>
                                 <li>
                                     <xref
-                                        href="command-pages/revoke.xml#concept_22551CABF07B4512B5159DDAE036722D"
+                                        href="command-pages/revoke.xml"
                                     />
                                 </li>
                                 <li>
@@ -182,7 +182,7 @@
                                 </li>
                                 <li>
                                     <xref
-                                        href="command-pages/validate.xml#concept_1A965E61EA7A4A629117CF55FC567685"
+                                        href="command-pages/validate.xml"
                                     />
                                 </li>
                             </ul>

--- a/tools_modules/gfsh/command-pages/alter.xml
+++ b/tools_modules/gfsh/command-pages/alter.xml
@@ -515,7 +515,7 @@ server1 | Region "/customer" altered on "server1"
 										"StatisticsArchiveFile.gfs". An empty string disables
 										archiving. Adding .gz suffix to the file name causes it to
 										be compressed. See <xref
-											href="../../../managing/statistics/chapter_overview.xml#statistics"
+											href="../../../managing/statistics/chapter_overview.xml"
 										/>.</entry>
 									<entry>
 										<i>not set</i>
@@ -527,7 +527,7 @@ server1 | Region "/customer" altered on "server1"
 									</entry>
 									<entry colname="col2">Statistic sampling rate. Valid values are
 										(in milliseconds): 100 - 60000. See <xref
-											href="../../../managing/statistics/chapter_overview.xml#statistics"
+											href="../../../managing/statistics/chapter_overview.xml"
 										/>. </entry>
 									<entry>1000</entry>
 								</row>
@@ -538,7 +538,7 @@ server1 | Region "/customer" altered on "server1"
 									<entry colname="col2">Whether statistic sampling should be
 										enabled. Valid values are: <codeph>true</codeph> and
 											<codeph>false</codeph>. See <xref
-											href="../../../managing/statistics/chapter_overview.xml#statistics"
+											href="../../../managing/statistics/chapter_overview.xml"
 										/>.</entry>
 									<entry>false</entry>
 								</row>
@@ -546,8 +546,8 @@ server1 | Region "/customer" altered on "server1"
 									<entry colname="col1">
 										<parmname>--copy-on-read</parmname>
 									</entry>
-									<entry colname="col2">True or false. Sets the "copy on read"
-										feature for cache read operations. See <xref
+									<entry colname="col2">True or false. Sets the "copy on read" feature for cache read
+										operations. See <xref
 											href="../../../basic_config/data_entries_custom_classes/managing_data_entries.xml#managing_data_entries/section_A0E0F889AC344EFA8DF304FD64418809"
 										/>.</entry>
 									<entry>false</entry>

--- a/tools_modules/gfsh/command-pages/clear.xml
+++ b/tools_modules/gfsh/command-pages/clear.xml
@@ -9,7 +9,7 @@
 			create a new set of indexes or if one or more of the index creations fail, you might
 			want to clear the definitions</p>
 		<p>See also <xref
-				href="define.xml#concept_B70E7B27CEF1496CB3B7217B15FF4726"/>.</p>
+				href="define.xml"/>.</p>
 		<p>
 			<b>Availability:</b> Online or offline. </p>
 		<p>

--- a/tools_modules/gfsh/command-pages/connect.xml
+++ b/tools_modules/gfsh/command-pages/connect.xml
@@ -11,9 +11,8 @@
 				Manager is. The locator knows when there is no member currently configured as the
 				JMX manager and simply starts up the JMX manager service within itself. gfsh
 				connects as a JMX client to locator JMX RMI port. </p>
-			<p>You can also <xref format="dita"
-					href="#concept_C2DCEE6743304549825C9B62E66DBADF/p_frf_n3k_2l">connect to a
-					remote locator</xref> using the HTTP protocol. </p>
+			<p>You can also connect to a remote
+					locator using the HTTP protocol, as illustrated by the second example below. </p>
 			<p><b> Availability:</b> Offline. You will receive a notification "Already connected to:
 				host[port]" if you are already connected. </p>
 			<p>
@@ -196,7 +195,7 @@ Connecting to Locator at [host=localhost, port=10334] ..
 Connecting to Manager at [host=GemFireStymon, port=1099] ..
 Successfully connected to: [host=GemFireStymon, port=1099]</codeblock>
 			</p>
-			<p id="p_frf_n3k_2l">
+			<p>
 				<b>Example of connecting to a remote locator over HTTP:</b>
 				<codeblock>gfsh>connect --use-http=true --url="http://myLocatorHost.com:8080/gemfire/v1"
 Successfully connected to: GemFire Manager's HTTP service @ http://myLocatorHost.com:8080/gemfire/v1</codeblock>

--- a/tools_modules/gfsh/command-pages/create.xml
+++ b/tools_modules/gfsh/command-pages/create.xml
@@ -168,8 +168,8 @@ create async-event-queue --id=myAEQ --listener=myApp.myListener
 			<title>create defined indexes</title>
 			<shortdesc>Creates all the defined indexes.</shortdesc>
 			<body>
-				<p>See also <xref href="define.xml#concept_B70E7B27CEF1496CB3B7217B15FF4726"/> and
-						<xref href="clear.xml#concept_B70E7B27CEF1496CB3B7217B15FF4726"/>.</p>
+				<p>See also <xref href="define.xml"/> and
+						<xref href="clear.xml"/>.</p>
 				<p><b> Availability:</b> Online. You must be connected in <parmname>gfsh</parmname>
 					to a JMX Manager member to use this command. </p>
 				<p>
@@ -232,7 +232,7 @@ Message : Region ' /r3' not found: from  /r3Occurred on following members
 			<shortdesc> Defines a pool of one or more disk stores, which can be used by regions and
 				client subscription queues. </shortdesc>
 			<body>
-				<p>See <xref href="../../../managing/disk_storage/chapter_overview.xml#disk_storage"
+				<p>See <xref href="../../../managing/disk_storage/chapter_overview.xml"
 					/></p>
 				<p><b> Availability:</b> Online. You must be connected in <parmname>gfsh</parmname>
 					to a JMX Manager member to use this command. </p>
@@ -398,7 +398,7 @@ server1 | Success</codeblock>
 			<body>
 				<p><b>Availability:</b> Online. You must be connected in <codeph>gfsh</codeph> to a
 					JMX Manager member to use this command. </p>
-				<p>See <xref href="../../../developing/query_index/query_index.xml#indexing"/>.</p>
+				<p>See <xref href="../../../developing/query_index/query_index.xml"/>.</p>
 				<p>
 					<b>Syntax:</b>
 					<codeblock>create index --name=value --expression=value --region=value 
@@ -505,7 +505,7 @@ Occurred on following members
 						<codeph>--value-constraint</codeph> makes object type information available
 					during querying and indexing. </p>
 				<p>See <xref
-						href="../../../developing/region_options/chapter_overview.xml#determining_storage_and_dist"
+						href="../../../developing/region_options/chapter_overview.xml"
 					/>. </p>
 				<p><b>Availability:</b> Online. You must be connected in <codeph>gfsh</codeph> to a
 					JMX Manager member to use this command. </p>

--- a/tools_modules/gfsh/command-pages/echo.xml
+++ b/tools_modules/gfsh/command-pages/echo.xml
@@ -5,7 +5,7 @@
 	<shortdesc>Echo the given text, which may include system and user variables. </shortdesc>
 	<conbody>
 		<p>The command can also echo gfsh environment properties (using '<xref
-				href="set.xml#concept_E9CC746480464556AA8FF69EB991776E" type="concept" format="dita"
+				href="set.xml" type="concept" format="dita"
 				scope="local">set variable</xref>' command) if variable name is pre-pended with '$'
 			- like UNIX. </p>
 		<p>See <xref

--- a/tools_modules/gfsh/command-pages/set.xml
+++ b/tools_modules/gfsh/command-pages/set.xml
@@ -7,7 +7,7 @@
 		<section id="section_66C36B0123F54A52AE3815E5D31F8239">
 			<p> Set GFSH variables that can be used by commands. </p>
 			<p>You can use the <codeph><xref format="dita"
-						href="echo.xml#concept_2828E2617F6A49D7BB811917BE268704" scope="local"
+						href="echo.xml" scope="local"
 						type="concept">echo</xref></codeph> command to view the value of a variable.
 				For example, to see a list of all environment variables and their current values,
 				use the following command: <codeblock>gfsh&gt;echo --string=$*</codeblock>See <xref

--- a/tools_modules/gfsh/command-pages/start.xml
+++ b/tools_modules/gfsh/command-pages/start.xml
@@ -14,7 +14,7 @@
 				<p>Note that you must have a JDK installed (not just a JRE) and the correct PATH and
 					JAVA_HOME environment variables set. </p>
 				<p>See <xref format="dita"
-						href="../../../managing/management/gemfire_mbeans_jconsole.xml#concept_492532E145834248997BD23BCAC7AD45"
+						href="../../../managing/management/gemfire_mbeans_jconsole.xml"
 						scope="local" type="concept"/> for an example of using JConsole with the
 						<keyword keyref="product_name"/><keyword keyref="product_name"/> management
 					and monitoring system. </p>
@@ -194,7 +194,7 @@ JDK installation or the JDK bin directory is in the system PATH.</codeblock>
 						not want the additional default GC properties set by the Resource Manager,
 						then use the<codeph>-Xms</codeph> and <codeph>-Xmx</codeph> JVM options. See
 							<xref format="dita"
-							href="../../../managing/heap_use/controlling_heap_use.xml#configuring_resource_manager"
+							href="../../../managing/heap_use/controlling_heap_use.xml"
 							scope="local" type="concept"/> for more information. </note>
 				</p>
 				<p><b> Availability:</b> Online or offline. </p>
@@ -472,7 +472,7 @@ Cluster configuration service is up and running.
 			<body>
 				<p> For more information on <keyword keyref="product_name"/> Pulse, see <xref
 						format="dita"
-						href="../../pulse/chapter_overview.xml#concept_600D5DC7303548BB96F5E3D1941C77C2"
+						href="../../pulse/chapter_overview.xml"
 						scope="local" type="concept"/>. </p>
 				<p><b> Availability:</b> Online or offline. </p>
 				<p>
@@ -511,7 +511,7 @@ Cluster configuration service is up and running.
 start pulse --url=http://gemfire.mycompany.com:7070/pulse</codeblock>
 				</p>
 				<p><b>Sample Output:</b> See <xref format="dita"
-						href="../../pulse/chapter_overview.xml#concept_600D5DC7303548BB96F5E3D1941C77C2"
+						href="../../pulse/chapter_overview.xml"
 						scope="local" type="concept"/> for examples of Pulse. </p>
 			</body>
 		</topic>
@@ -527,7 +527,7 @@ start pulse --url=http://gemfire.mycompany.com:7070/pulse</codeblock>
 						additional default GC properties set by the Resource Manager, then use the
 							<codeph>-Xms</codeph> and <codeph>-Xmx</codeph> JVM options. See <xref
 							format="dita"
-							href="../../../managing/heap_use/controlling_heap_use.xml#configuring_resource_manager"
+							href="../../../managing/heap_use/controlling_heap_use.xml"
 							scope="local" type="concept"/> for more information. </note>
 				</p>
 				<p><b> Availability:</b> Online or offline. </p>

--- a/tools_modules/gfsh/command-pages/status.xml
+++ b/tools_modules/gfsh/command-pages/status.xml
@@ -78,7 +78,7 @@ locator8 | RUNNING
 										display status. You must be connected to the JMX Manager to
 										use this option. Can be used to obtain status of remote
 										locators. See <xref
-											href="../../../configuring/cluster_config/gfsh_remote.xml#task_nyb_mhn_44"
+											href="../../../configuring/cluster_config/gfsh_remote.xml"
 										/>.</entry>
 									<entry/>
 								</row>
@@ -172,7 +172,7 @@ Cluster configuration service is up and running.
 										to display status. You must be connected to the JMX Manager
 										to use this option. Can be used to obtain status of remote
 										servers. See <xref
-											href="../../../configuring/cluster_config/gfsh_remote.xml#task_nyb_mhn_44"
+											href="../../../configuring/cluster_config/gfsh_remote.xml"
 										/>.</entry>
 									<entry/>
 								</row>

--- a/tools_modules/gfsh/command-pages/stop.xml
+++ b/tools_modules/gfsh/command-pages/stop.xml
@@ -37,7 +37,7 @@
 										member name or id of the Locator to stop. You must be
 										connected to the JMX Manager to use this option. Can be used
 										to stop remote locators. See <xref
-											href="../../../configuring/cluster_config/gfsh_remote.xml#task_nyb_mhn_44"
+											href="../../../configuring/cluster_config/gfsh_remote.xml"
 										/>. </entry>
 									<entry/>
 								</row>
@@ -113,7 +113,7 @@ gfsh>
 											keyref="product_name"/> Cache Server to stop. You must
 										be connected to the JMX Manager to use this option. Can be
 										used to stop remote servers. See <xref
-											href="../../../configuring/cluster_config/gfsh_remote.xml#task_nyb_mhn_44"
+											href="../../../configuring/cluster_config/gfsh_remote.xml"
 										/>. </entry>
 									<entry/>
 								</row>

--- a/tools_modules/gfsh/command_scripting.xml
+++ b/tools_modules/gfsh/command_scripting.xml
@@ -11,7 +11,7 @@
 			<title>Running gfsh Scripts</title>
 			<p>You can create and run scripts that contain gfsh commands that
 				you wish to execute. To execute the script, use the gfsh <xref
-					href="command-pages/run.xml#concept_970BC9839C8243AF86CAEAAB22FDF40C"
+					href="command-pages/run.xml"
 					type="concept"
 					format="dita"
 					scope="local">run</xref> command. For example:

--- a/tools_modules/gfsh/quick_ref_commands_by_area.xml
+++ b/tools_modules/gfsh/quick_ref_commands_by_area.xml
@@ -21,7 +21,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/debug.xml#concept_B70E7B27CEF1496CB3B7217B15FF4726"
+									href="command-pages/debug.xml"
 								/>
 							</entry>
 							<entry>Enable or disable debugging output in <codeph>gfsh</codeph>. </entry>
@@ -30,7 +30,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/echo.xml#concept_2828E2617F6A49D7BB811917BE268704"
+									href="command-pages/echo.xml"
 								/>
 							</entry>
 							<entry>Echo the given text, which may include system and user variables. </entry>
@@ -48,7 +48,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/exit.xml#concept_11976C820D63433899CF1530F1FB849F"
+									href="command-pages/exit.xml"
 								/>
 							</entry>
 							<entry>Exit the gfsh shell. You can also use <codeph>quit</codeph> to
@@ -58,7 +58,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/help.xml#concept_52B3A347D6FC4DF392FD16C164D959A5"
+									href="command-pages/help.xml"
 								/>
 							</entry>
 							<entry>If the argument is a gfsh command, displays syntax and usage
@@ -69,7 +69,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/hint.xml#concept_0FD387293BE14CB5B3CC2C6ADA90AAFB"
+									href="command-pages/hint.xml"
 								/>
 							</entry>
 							<entry>Display information on topics and a list of commands associated
@@ -79,7 +79,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/history.xml#concept_3C89B4C4D3EA47DE9CB046286D26F0BC"
+									href="command-pages/history.xml"
 								/>
 							</entry>
 							<entry>Show or save the command history.</entry>
@@ -88,7 +88,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/run.xml#concept_970BC9839C8243AF86CAEAAB22FDF40C"
+									href="command-pages/run.xml"
 								/>
 							</entry>
 							<entry>Execute a set of GFSH commands. </entry>
@@ -97,7 +97,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/set.xml#concept_E9CC746480464556AA8FF69EB991776E"
+									href="command-pages/set.xml"
 								/>
 							</entry>
 							<entry>Set variables in the GFSH environment. </entry>
@@ -106,7 +106,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/sh.xml#concept_E6D5DCFCDFC0433EA2A9AD7AB9B904D6"
+									href="command-pages/sh.xml"
 								/>
 							</entry>
 							<entry>Executes operating system (OS) commands. </entry>
@@ -115,7 +115,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/sleep.xml#concept_249C98CFF0BF4BCCA7778AE2D751F52E"
+									href="command-pages/sleep.xml"
 								/>
 							</entry>
 							<entry>Delay <codeph>gfsh</codeph> command execution. </entry>
@@ -124,7 +124,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/version.xml#concept_DEBBA885D95243ABA510416F731D0E75"
+									href="command-pages/version.xml"
 								/>
 							</entry>
 							<entry>Display product version information.</entry>
@@ -253,7 +253,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/get.xml#concept_837F6196CE334C8CA2CAFD34AB6EF869"
+									href="command-pages/get.xml"
 								/>
 							</entry>
 							<entry>Display an entry in a region.</entry>
@@ -278,7 +278,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/put.xml#concept_2ECE1BB23A814A13924C93422E7EBC5E"
+									href="command-pages/put.xml"
 								/>
 							</entry>
 							<entry>Add or update a region entry. </entry>
@@ -287,7 +287,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/query.xml#concept_89A129F729DF4D3B9056C8D9016AA760"
+									href="command-pages/query.xml"
 								/>
 							</entry>
 							<entry>Run queries against <keyword keyref="product_name"/>
@@ -297,7 +297,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/remove.xml#concept_D452C829146D434CB5069126D93944FD"
+									href="command-pages/remove.xml"
 								/>
 							</entry>
 							<entry>Remove an entry from a region.</entry>
@@ -328,7 +328,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/deploy.xml#concept_6B38CB283BC048778A8E3908C1BDF221"
+									href="command-pages/deploy.xml"
 								/>
 							</entry>
 							<entry> Deploy JAR-packaged applications to a member or members.</entry>
@@ -347,7 +347,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/undeploy.xml#concept_234FEC313B4A468E8851DD9B1B759B98"
+									href="command-pages/undeploy.xml"
 								/>
 							</entry>
 							<entry>Undeploy the JAR files that were deployed on members or groups
@@ -460,7 +460,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/revoke.xml#concept_22551CABF07B4512B5159DDAE036722D"
+									href="command-pages/revoke.xml"
 								/>
 							</entry>
 							<entry>Instruct the member(s) of a distributed system to stop waiting
@@ -492,7 +492,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/validate.xml#concept_1A965E61EA7A4A629117CF55FC567685"
+									href="command-pages/validate.xml"
 								/>
 							</entry>
 							<entry>Validate offline disk stores.</entry>
@@ -677,7 +677,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/gc.xml#concept_95E57FE81F5244FB810C58816212323E"
+									href="command-pages/gc.xml"
 								/>
 							</entry>
 							<entry>Force garbage collection on a member or members. </entry>
@@ -702,7 +702,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/netstat.xml#concept_8B8D6D6E3CE84B46ABCFE59B63F15684"
+									href="command-pages/netstat.xml"
 								/>
 							</entry>
 							<entry>Report network information and statistics via the "netstat"
@@ -740,7 +740,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/shutdown.xml#concept_249C98CFF0BF4BCCA7778AE2D751F52E"
+									href="command-pages/shutdown.xml"
 								/>
 							</entry>
 							<entry>Shut down all members that have a cache. </entry>
@@ -801,7 +801,7 @@
 					<tbody>
 						<row>
 							<entry><xref
-									href="command-pages/clear.xml#concept_B70E7B27CEF1496CB3B7217B15FF4726"
+									href="command-pages/clear.xml"
 								/></entry>
 							<entry>Clears all the defined indexes.</entry>
 							<entry>online, offline</entry>
@@ -821,7 +821,7 @@
 						</row>
 						<row>
 							<entry><xref
-									href="command-pages/define.xml#concept_B70E7B27CEF1496CB3B7217B15FF4726"
+									href="command-pages/define.xml"
 								/></entry>
 							<entry>Define an index that can be used when executing queries. Then you
 								can create multiple indexes all at once.</entry>
@@ -868,7 +868,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/connect.xml#concept_C2DCEE6743304549825C9B62E66DBADF"
+									href="command-pages/connect.xml"
 								/>
 							</entry>
 							<entry>Connect to a jmx-manager either directly or via a locator. </entry>
@@ -886,7 +886,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/disconnect.xml#concept_F2E124F14F24418990BFFCD5A5355BEC"
+									href="command-pages/disconnect.xml"
 								/>
 							</entry>
 							<entry>Close any active connection(s).</entry>
@@ -975,7 +975,7 @@
 							<entry>online, offline</entry>
 						</row>
 						<row>
-							<entry><xref href="command-pages/pdx.xml#concept_bkv_p4f_qq"/>
+							<entry><xref href="command-pages/pdx.xml"/>
 							</entry>
 							<entry>Renames PDX types in an offline disk store.</entry>
 							<entry>online, offline</entry>
@@ -1052,7 +1052,7 @@
 						<row>
 							<entry>
 								<xref
-									href="command-pages/rebalance.xml#concept_213FDC5574474CE1AC28444DA202E05B"
+									href="command-pages/rebalance.xml"
 								/>
 							</entry>
 							<entry> Rebalance partitioned regions.</entry>

--- a/tools_modules/gfsh/tour_of_gfsh.xml
+++ b/tools_modules/gfsh/tour_of_gfsh.xml
@@ -95,7 +95,7 @@ Connecting to Manager at [host=localhost, port=1099] ..
 Successfully connected to: [host=localhost, port=1099]
 </codeblock>
 				In addition, you can connect to remote clusters over HTTP. See <xref
-					href="../../configuring/cluster_config/gfsh_remote.xml#task_nyb_mhn_44"
+					href="../../configuring/cluster_config/gfsh_remote.xml"
 					/>.</p><p><b>Step 5: Disconnect and close the second terminal window. </b>Type
 				the following commands to disconnect and exit the second <codeph>gfsh</codeph>
 				prompt:

--- a/tools_modules/hibernate_cache/advanced_config.xml
+++ b/tools_modules/hibernate_cache/advanced_config.xml
@@ -75,7 +75,7 @@
 				which basic topology is suited for your usage. The configuration process is slightly
 				different for each topology. For general information about <keyword
 					keyref="product_name"/> topologies, refer to <xref
-					href="../../topologies_and_comm/book_intro.xml#concept_7628F498DB534A2D8A99748F5DA5DC94"
+					href="../../topologies_and_comm/book_intro.xml"
 				/>.</p>
 			<ul id="fig_ECD3D1C6B43149EF853EC973D28F492D">
 				<li id="li_860E5673EDC04D04AD425A52BF3DA99C">

--- a/tools_modules/hibernate_cache/changing_gemfire_default_cfg.xml
+++ b/tools_modules/hibernate_cache/changing_gemfire_default_cfg.xml
@@ -46,7 +46,7 @@ In Windows:
 			<p>You can change the region attributes from within the
 					<codeph>hibernate.cfg.xml</codeph> file using the same region shortcuts
 				specified in <xref
-					href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts"
+					href="../../basic_config/data_regions/region_shortcuts.xml"
 					type="concept" format="dita" scope="local"
 					><?xm-replace_text Region Shortcuts and Custom Named Region Attributes?></xref>.
 				<codeblock>&lt;property name="gemfire.default-region-attributes-id"&gt;
@@ -127,7 +127,7 @@ In Windows:
 				client will not cache data. </p>
 			<p>You can change the client region attributes from within the hibernate.cfg.xml file
 				using the same client region shortcuts specified in <xref
-					href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts"
+					href="../../basic_config/data_regions/region_shortcuts.xml"
 					type="concept" format="dita" scope="local"
 					><?xm-replace_text Region Shortcuts and Custom Named Region Attributes?></xref>. </p>
 			<codeblock>&lt;property name="gemfire.default-client-region-attributes-id"&gt;
@@ -180,7 +180,7 @@ In Windows:
   prompt&gt; cacheserver.bat start locators=hostname[port]</codeblock>
 			<p>If you are running more than one locator, use a comma-separated list of locators.
 				Refer to <xref
-					href="../../configuring/running/running_the_cacheserver.xml#running_the_cacheserver"
+					href="../../configuring/running/running_the_cacheserver.xml"
 					type="concept" format="dita" scope="local"/> for more information on using this
 				script. </p>
 			<note>When running the cache server, make sure the Hibernate jar and the <keyword

--- a/tools_modules/http_session_mgmt/common_gemfire_topologies.xml
+++ b/tools_modules/http_session_mgmt/common_gemfire_topologies.xml
@@ -7,7 +7,7 @@
 	<conbody>
 		<p> For general information about <keyword keyref="product_name_long"/> topologies, refer to
 				<xref
-				href="../../topologies_and_comm/book_intro.xml#concept_7628F498DB534A2D8A99748F5DA5DC94"
+				href="../../topologies_and_comm/book_intro.xml"
 			/>. </p>
 		<section id="p2p_configuration">
 			<title>Peer-to-Peer Configuration</title>

--- a/tools_modules/http_session_mgmt/interactive_mode_ref.xml
+++ b/tools_modules/http_session_mgmt/interactive_mode_ref.xml
@@ -40,7 +40,7 @@ With the gemfire-cs template:
 		<p>The above property determines the ID of the attributes for the cache region; possible
 			values include PARTITION, PARTITION_REDUNDANT, PARTITION_PERSISTENT, REPLICATE,
 			REPLICATE_PERSISTENT, and any other region shortcut that can be found in <xref
-				href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts"
+				href="../../basic_config/data_regions/region_shortcuts.xml"
 				type="concept" format="dita" scope="local"
 				><?xm-replace_text Region Shortcuts and Custom Named Region Attributes?></xref>.
 			When using a partitioned region attribute, it is recommended that you use
@@ -107,7 +107,7 @@ With the gemfire-cs template:
 		<codeblock>  Please specify whether GemFire statistic sampling should be enabled. 
   Default 'false':</codeblock>
 		<p>The above property determines whether statistics sampling should occur. See <xref
-				href="../../managing/statistics/chapter_overview.xml#statistics" type="concept"
+				href="../../managing/statistics/chapter_overview.xml" type="concept"
 				format="dita" scope="local"/> for more information. </p>
 	</conbody>
 </concept>

--- a/tools_modules/http_session_mgmt/quick_start.xml
+++ b/tools_modules/http_session_mgmt/quick_start.xml
@@ -278,7 +278,7 @@
 		<section id="section_EE60463F524A46B7B83CE74C1C3E8E0E">
 			<title>Additional Quick Start Instructions for tc Server Module</title>
 			<p>These steps provide a basic starting point for using the tc Server module. For more
-				configuration options, see <xref href="session_mgmt_tcserver.xml#http_tc_server"
+				configuration options, see <xref href="session_mgmt_tcserver.xml"
 					type="concept" format="dita" scope="local"/>. <ol
 					id="ol_9F97B5EC18E34D278BEF7D128CDE0E57">
 					<li id="li_FD4958D29B714ADFABCA63F0BE6BB1A4">Navigate to the root directory of
@@ -304,7 +304,7 @@ prompt$ ./tcruntime-ctl.sh my_instance_name start</codeblock>
 		<section id="section_4689A4FA609A4F4FB091F03E9BECA4DB">
 			<title>Additional Quick Start Instructions for Tomcat Module</title>
 			<p>These steps provide a basic starting point for using the Tomcat module. For more
-				configuration options, see <xref href="session_mgmt_tomcat.xml#http_tomcat_first"
+				configuration options, see <xref href="session_mgmt_tomcat.xml"
 					type="concept" format="dita" scope="local"/>. <ol
 					id="ol_88CF6319267D4C65AA872BD695C1065C">
 					<li id="li_A72CA5E5A2324B7F9A42D765985FA005">Modify Tomcat's
@@ -320,7 +320,7 @@ prompt$ ./tcruntime-ctl.sh my_instance_name start</codeblock>
 							<codeblock>&lt;Manager className="com.gemstone.gemfire.modules.session.catalina.
                          Tomcat7DeltaSessionManager"/&gt; </codeblock>See
 								<xref
-								href="tomcat_setting_up_the_module.xml#tomcat_setting_up_the_module"
+								href="tomcat_setting_up_the_module.xml"
 								type="concept" format="dita" scope="local"/> for additional
 							instructions. </p>
 					</li>
@@ -333,7 +333,7 @@ prompt$ ./tcruntime-ctl.sh my_instance_name start</codeblock>
 			<title>Additional Instructions for AppServers Module</title>
 			<p>These steps provide a basic starting point for using the AppServers module with
 				WebLogic, WebSphere or JBoss. For more configuration options, see <xref
-					href="session_mgmt_weblogic.xml#http_weblogic_first" type="concept"
+					href="session_mgmt_weblogic.xml" type="concept"
 					format="dita" scope="local"/>. <note>
 					<ul id="ul_8844FFA8319F44BFAF3DDF1E430B73EC">
 						<li id="li_0052B12E1C6E4EF79B7A0B80655DD4C4">The <codeph>modify_war</codeph>

--- a/tools_modules/http_session_mgmt/session_mgmt_tcserver.xml
+++ b/tools_modules/http_session_mgmt/session_mgmt_tcserver.xml
@@ -7,7 +7,7 @@
 	<conbody>
 		<p>If you would prefer to manually change the <codeph>server.xml</codeph> and
 				<codeph>context.xml</codeph> files rather than use tc Server templates, refer to
-				<xref href="session_mgmt_tomcat.xml#http_tomcat_first" type="concept" format="dita"
+				<xref href="session_mgmt_tomcat.xml" type="concept" format="dita"
 				scope="local"/>. </p>
 	</conbody>
 </concept>

--- a/tools_modules/http_session_mgmt/session_mgmt_tomcat.xml
+++ b/tools_modules/http_session_mgmt/session_mgmt_tomcat.xml
@@ -6,7 +6,7 @@
 		and <codeph>context.xml</codeph> files. </shortdesc>
 	<conbody>
 		<p> For instructions specific to SpringSource tc Server templates, refer to <xref
-				href="session_mgmt_tcserver.xml#http_tc_server" type="concept" format="dita"
+				href="session_mgmt_tcserver.xml" type="concept" format="dita"
 				scope="local"
 				><?xm-replace_text HTTP Session Management Module for tc Server?></xref>. </p>
 	</conbody>

--- a/tools_modules/http_session_mgmt/tc_installing_the_module.xml
+++ b/tools_modules/http_session_mgmt/tc_installing_the_module.xml
@@ -15,7 +15,7 @@
 						scope="external">Pivotal tc Server download page</xref>. These instructions
 					require <b>tc Server 2.1</b> or later. (If you are using an older version of tc
 					Server, you should set up the plug-in without templates: <xref
-						href="session_mgmt_tomcat.xml#http_tomcat_first" type="concept"
+						href="session_mgmt_tomcat.xml" type="concept"
 						format="dita" scope="local"
 						><?xm-replace_text HTTP Session Management Module for Tomcat?></xref>.) </li>
 				<li id="li_2C08538D1E364E6B859799A6CF05807F">If you have not already downloaded and

--- a/tools_modules/http_session_mgmt/tomcat_changing_gf_default_cfg.xml
+++ b/tools_modules/http_session_mgmt/tomcat_changing_gf_default_cfg.xml
@@ -229,7 +229,7 @@ ClientCache.createClientRegionFactory(CACHING_PROXY_HEAP_LRU)</codeblock>
 					<pt>regionAttributesId </pt>
 					<pd>
 						<p>Specifies the region shortcut. For more information see <xref
-								href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts"
+								href="../../basic_config/data_regions/region_shortcuts.xml"
 								type="concept" format="dita" scope="local"
 								><?xm-replace_text Region Shortcuts and Custom Named Region Attributes?></xref>;
 							when using a partitioned region attribute, it is recommended that you

--- a/tools_modules/http_session_mgmt/weblogic_changing_gf_default_cfg.xml
+++ b/tools_modules/http_session_mgmt/weblogic_changing_gf_default_cfg.xml
@@ -247,7 +247,7 @@ ClientCache.<xref format="html" href="http://www.gemstone.com/docs/current/produ
 					<pt>region_attributes_id </pt>
 					<pd>
 						<p>Specifies the region shortcut; for more information refer to <xref
-								href="../../basic_config/data_regions/region_shortcuts.xml#region_shortcuts"
+								href="../../basic_config/data_regions/region_shortcuts.xml"
 								type="concept" format="dita" scope="local"/>; when using a
 							partitioned region attribute, it is recommended that you use
 							PARTITION_REDUNDANT (rather than PARTITION) to ensure that the failure

--- a/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.xml
+++ b/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.xml
@@ -270,7 +270,7 @@ Class-Path: lib/gemfire-6.6.3.jar
 In Windows:
   prompt&gt; cacheserver.bat start </codeblock>
 			<p>See <xref
-					href="../../configuring/running/running_the_cacheserver.xml#running_the_cacheserver"
+					href="../../configuring/running/running_the_cacheserver.xml"
 					type="concept" format="dita" scope="local"/> for more information on using this
 				script. </p>
 			<p>If you plan to use the deprecated cacheserver script that comes with the standalone

--- a/tools_modules/pulse/quickstart.xml
+++ b/tools_modules/pulse/quickstart.xml
@@ -479,7 +479,7 @@ CLASSPATH=$CLASSPATH:/opt/pulse-config</codeblock></li>
 					<li>http-service-ssl-truststore</li>
 					<li>http-service-ssl-truststore-password</li>
 				</ul>
-				<p dir="ltr">See <xref href="../../managing/security/ssl_overview.xml#ssl"/> for
+				<p dir="ltr">See <xref href="../../managing/security/ssl_overview.xml"/> for
 					details on configuring these parameters.</p>
 				<p dir="ltr">The above parameters apply to all HTTP services hosted on the JMX
 					Manager, which includes the following:</p>
@@ -1043,7 +1043,7 @@ CLASSPATH=$CLASSPATH:/opt/pulse-config</codeblock></li>
 						<li>Select one or more members from the Region Members section to restrict
 							query results to those members. </li>
 						<li>Type in the text of a query to execute. See <xref
-								href="../../developing/querying_basics/chapter_overview.xml#querying_with_oql"
+								href="../../developing/querying_basics/chapter_overview.xml"
 							/>.</li>
 						<li>Display a list of previously-executed queries. Double-click on a query
 							from the history list to copy it to the Query Editor, or delete the

--- a/topologies_and_comm/cs_configuration/setting_up_a_client_server_system.xml
+++ b/topologies_and_comm/cs_configuration/setting_up_a_client_server_system.xml
@@ -10,7 +10,7 @@
 			<ul id="ul_2FD1AB100D0147C892486C126477BE65">
 				<li id="li_BE5007821EC94C49B15B73668278AD1D">Configure your server system using
 					locators for member discovery. See <xref format="dita"
-						href="../p2p_configuration/setting_up_a_p2p_system.xml#setting_up_membership"
+						href="../p2p_configuration/setting_up_a_p2p_system.xml"
 						scope="local" type="concept"/> and <xref format="dita"
 						href="../../basic_config/the_cache/managing_a_peer_server_cache.xml#creating_and_closing_a_peer_cache"
 						scope="local" type="concept"/>. </li>

--- a/topologies_and_comm/p2p_configuration/setting_up_a_p2p_system.xml
+++ b/topologies_and_comm/p2p_configuration/setting_up_a_p2p_system.xml
@@ -10,13 +10,11 @@
 		<section id="section_8C0147A16D5A488FB9C0EB765BDEC07B">
 			<p>Before you begin, you should have a basic understanding of member discovery. You
 				should also have already determined the address and port settings for member
-				discovery. See <xref
-					href="../topology_concepts/chapter_overview.xml#concept_7628F498DB534A2D8A99748F5DA5DC94"
-					format="dita"/>. </p>
+				discovery. See <xref href="../topology_concepts/chapter_overview.xml" format="dita"
+				/>. </p>
 			<p>These options are set through <keyword keyref="product_name"/> properties. See <xref
-					href="../../reference/topics/gemfire_properties.xml#gemfire_properties"
-					type="concept" format="dita" scope="local"/>. <ul
-					id="ul_342764F44EF74999ACFC9222B8335554">
+					href="../../reference/topics/gemfire_properties.xml" type="concept"
+					format="dita" scope="local"/>. <ul id="ul_342764F44EF74999ACFC9222B8335554">
 					<li id="li_A79E816A149848198B710AD8C007320B">To use <b>multicast</b> for
 						membership, in the <codeph>gemfire.properties</codeph> for all system peers,
 						provide the multicast address and port and disable locators for peer
@@ -31,8 +29,8 @@ mcast-port=&lt;mcast port&gt;</codeblock>
 						<codeblock>locators=&lt;locator1-address&gt;[&lt;port1&gt;],&lt;locator2-address&gt;[&lt;port2&gt;]</codeblock>By
 						default, locators provide peer discovery in the system in which they run, so
 						no special settings are required to enable it when you start them. See <xref
-							href="../../configuring/running/running_the_locator.xml#running_the_locator"
-							type="concept" format="dita" scope="local"/>. </li>
+							href="../../configuring/running/running_the_locator.xml" type="concept"
+							format="dita" scope="local"/>. </li>
 					<li id="li_C980AFC673BD4D4C84D395766C21BA91">To run a standalone member, in the
 							<codeph>gemfire.properties</codeph> disable multicasting and locators:
 						<codeblock>locators=

--- a/topologies_and_comm/p2p_configuration/setting_up_peer_communication.xml
+++ b/topologies_and_comm/p2p_configuration/setting_up_peer_communication.xml
@@ -10,7 +10,7 @@
 			<p>Before you begin, you should have a basic understanding of member discovery. You
 				should also have already determined the address and port settings for multicasting,
 				including any bind addresses. See <xref
-					href="../topology_concepts/chapter_overview.xml#concept_7628F498DB534A2D8A99748F5DA5DC94"
+					href="../topology_concepts/chapter_overview.xml"
 					format="dita"/>. </p>
 			<p>See <xref href="../../reference/topics/gemfire_properties.xml#gemfire_properties"
 					type="concept" format="dita" scope="local"/> and <xref

--- a/topologies_and_comm/topology_concepts/member_communication.xml
+++ b/topologies_and_comm/topology_concepts/member_communication.xml
@@ -52,11 +52,11 @@
 					</li>
 					<li id="li_884B6067FDF141579042360D07AEBE9D">Set up membership in your systems.
 						See <xref
-							href="../p2p_configuration/setting_up_a_p2p_system.xml#setting_up_membership"
+							href="../p2p_configuration/setting_up_a_p2p_system.xml"
 							type="concept" format="dita" scope="local"/>. </li>
 					<li id="li_FF878A26723941B39A02CD496E2C5380">Set up communication between system
 						members. See <xref
-							href="../p2p_configuration/setting_up_peer_communication.xml#setting_up_communication"
+							href="../p2p_configuration/setting_up_peer_communication.xml"
 							type="concept" format="dita" scope="local"/>. </li>
 					<li id="li_ECB41DC09D5148DE8BB80DC0A10FC312">As needed, set up communication
 						between your systems. See <xref

--- a/topologies_and_comm/topology_concepts/using_bind_addresses.xml
+++ b/topologies_and_comm/topology_concepts/using_bind_addresses.xml
@@ -20,7 +20,7 @@
 				example, if you use bind addresses for your server locators, you must use the same
 				addresses to configure the server pools in your clients. <p>Use IPv4 or IPv6 numeric
 					address specifications for your bind address settings. For information on these
-					specifications, see <xref href="IPv4_and_IPv6.xml#IPv4_and_IPv6" type="concept"
+					specifications, see <xref href="IPv4_and_IPv6.xml" type="concept"
 						format="dita" scope="local"/>. Do not use host names for your address
 					specifications. Host names resolve to default machine addresses. </p>
 			</note>
@@ -154,7 +154,7 @@ bind-address=194.124.0.104</codeblock>
 						<row>
 							<entry>
 								<xref
-									href="../../configuring/running/running_the_locator.xml#running_the_locator"
+									href="../../configuring/running/running_the_locator.xml"
 									type="concept" format="dita" scope="local"/>
 							</entry>
 						</row>


### PR DESCRIPTION
No actual content changes. Fixes many broken link messages in the bookbinder build by removing IDs from cross references that target topics. 